### PR TITLE
Integrate countdown timer

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,8 @@ python3 pomodoro.py
 
 The first time a work session completes, the count for the current day increases. The count is stored in `pomodoro_data.json` in the same directory.
 
+## Countdown Timer
+
+The Pomodoro window includes an **Open Countdown** button that launches a
+separate countdown timer page. Use it when you need a quick timer outside the
+Pomodoro workflow.


### PR DESCRIPTION
## Summary
- integrate countdown timer functionality into `pomodoro.py`
- remove standalone `countdown.py`
- document how to open the countdown timer from the Pomodoro window

## Testing
- `python3 -m py_compile pomodoro.py`


------
https://chatgpt.com/codex/tasks/task_e_68664648c81c8323bd6ef37a59c047aa