### PR TITLE
Add music player launcher to pomodoro UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,24 @@ The first time a work session completes, the count for the current day increases
 ## Countdown Timer
 
 
+The repository also includes a countdown timer and a minimal music player.
+
+### Countdown Timer
+Run the simple timer or open it from the Pomodoro app with the "Open Countdown" button:
+
+```bash
+python3 countdown.py
+```
+
+### Music Player
+You can open the player from the Pomodoro window using the "Open Music Player"
+button, or run it standalone. The script lets you open a local audio file,
+view its basic ID3v1 metadata, and play it using the operating system's default
+utilities. Launch it with:
+
+```bash
+python3 music_player.py
+```
+
+Only basic playback commands (play/stop) are provided and the script falls back
+on commands like `afplay` or `aplay` depending on your platform.

--- a/music_player.py
+++ b/music_player.py
@@ -1,0 +1,98 @@
+import os
+import sys
+import subprocess
+import tkinter as tk
+from tkinter import filedialog, messagebox
+
+
+def read_id3v1_tags(path):
+    """Return title and artist from ID3v1 tag if present."""
+    try:
+        with open(path, 'rb') as f:
+            f.seek(-128, os.SEEK_END)
+            tag = f.read(128)
+            if tag[:3] == b'TAG':
+                title = tag[3:33].decode('latin-1').strip('\x00').strip()
+                artist = tag[33:63].decode('latin-1').strip('\x00').strip()
+                return title or os.path.basename(path), artist
+    except Exception:
+        pass
+    return os.path.basename(path), ''
+
+
+def play_audio(path):
+    """Attempt to play audio using built-in OS commands."""
+    try:
+        if sys.platform == 'darwin':
+            return subprocess.Popen(['afplay', path])
+        elif sys.platform.startswith('win'):
+            import winsound
+            winsound.PlaySound(path, winsound.SND_FILENAME | winsound.SND_ASYNC)
+            return None
+        else:
+            return subprocess.Popen(['aplay', path])
+    except FileNotFoundError:
+        messagebox.showerror('Error', 'No suitable audio player found.')
+        return None
+
+
+nplayers = []
+
+
+class MusicPlayerApp:
+    def __init__(self, master):
+        self.master = master
+        master.title('Simple Music Player')
+
+        self.filepath = ''
+        self.process = None
+
+        self.title_var = tk.StringVar()
+        self.artist_var = tk.StringVar()
+
+        tk.Button(master, text='Open', command=self.open_file).grid(row=0, column=0)
+        tk.Button(master, text='Play', command=self.play).grid(row=0, column=1)
+        tk.Button(master, text='Stop', command=self.stop).grid(row=0, column=2)
+
+        tk.Label(master, text='Title:').grid(row=1, column=0, sticky='e')
+        tk.Label(master, text='Artist:').grid(row=2, column=0, sticky='e')
+        tk.Label(master, textvariable=self.title_var).grid(row=1, column=1, columnspan=2, sticky='w')
+        tk.Label(master, textvariable=self.artist_var).grid(row=2, column=1, columnspan=2, sticky='w')
+
+    def apply_theme(self, bg: str, fg: str):
+        """Apply background/foreground colors to widgets."""
+        self.master.configure(bg=bg)
+        for child in self.master.winfo_children():
+            if isinstance(child, (tk.Button, tk.Label)):
+                child.configure(bg=bg, fg=fg)
+
+    def open_file(self):
+        path = filedialog.askopenfilename(title='Open Music File',
+                                          filetypes=[('Audio files', '*.mp3 *.wav *.ogg *.flac'),
+                                                     ('All files', '*.*')])
+        if path:
+            self.filepath = path
+            title, artist = read_id3v1_tags(path)
+            self.title_var.set(title)
+            self.artist_var.set(artist or 'Unknown')
+
+    def play(self):
+        if not self.filepath:
+            messagebox.showwarning('No file', 'Please open a music file first.')
+            return
+        self.stop()
+        self.process = play_audio(self.filepath)
+
+    def stop(self):
+        if self.process is not None:
+            self.process.terminate()
+            self.process = None
+        if sys.platform.startswith('win'):
+            import winsound
+            winsound.PlaySound(None, winsound.SND_PURGE)
+
+
+if __name__ == '__main__':
+    root = tk.Tk()
+    app = MusicPlayerApp(root)
+    root.mainloop()

--- a/pomodoro.py
+++ b/pomodoro.py
@@ -2,6 +2,7 @@ import json
 import os
 import tkinter as tk
 from tkinter import messagebox
+from music_player import MusicPlayerApp
 from datetime import date
 
 DATA_FILE = 'pomodoro_data.json'
@@ -119,6 +120,10 @@ class PomodoroApp:
                                           command=self.open_countdown)
         self.countdown_button.grid(row=6, column=0, columnspan=3, pady=(5, 0))
 
+        self.music_button = tk.Button(master, text='Open Music Player',
+                                      command=self.open_music_player)
+        self.music_button.grid(row=7, column=0, columnspan=3, pady=(5, 0))
+
     def load_data(self):
         today = date.today().isoformat()
         if os.path.exists(DATA_FILE):
@@ -166,6 +171,13 @@ class PomodoroApp:
         win = CountdownWindow(self.master)
         if self.dark_mode_var.get():
             win.apply_theme('#2e2e2e', '#ffffff')
+
+    def open_music_player(self):
+        """Open the simple music player window."""
+        win = tk.Toplevel(self.master)
+        player = MusicPlayerApp(win)
+        if self.dark_mode_var.get() and hasattr(player, 'apply_theme'):
+            player.apply_theme('#2e2e2e', '#ffffff')
 
     def start(self):
         if not self.running:


### PR DESCRIPTION
## Summary
- link the existing music player to the pomodoro interface
- provide dark-mode theming support in the music player
- document how to open these tools from the main window

## Testing
- `python3 -m py_compile music_player.py pomodoro.py countdown.py`

------
https://chatgpt.com/codex/tasks/task_e_68664eb0fad48323bd4dfb5551dca9c4