### PR TITLE
Add metadata labels to music player

### DIFF
--- a/music_player.py
+++ b/music_player.py
@@ -57,6 +57,12 @@ class MusicPlayerApp:
         tk.Button(master, text='Play', command=self.play).grid(row=0, column=1)
         tk.Button(master, text='Stop', command=self.stop).grid(row=0, column=2)
 
+        tk.Label(master, text='Title:').grid(row=1, column=0, sticky='e')
+        tk.Label(master, textvariable=self.title_var, anchor='w').grid(row=1, column=1, columnspan=2, sticky='w')
+
+        tk.Label(master, text='Artist:').grid(row=2, column=0, sticky='e')
+        tk.Label(master, textvariable=self.artist_var, anchor='w').grid(row=2, column=1, columnspan=2, sticky='w')
+
 
     def apply_theme(self, bg: str, fg: str):
         """Apply background/foreground colors to widgets."""


### PR DESCRIPTION
## Summary
- show track title and artist below player buttons
- keep them styled when themes are applied
- metadata now displays when a file is opened

## Testing
- `python3 -m py_compile music_player.py pomodoro.py countdown.py`

------
https://chatgpt.com/codex/tasks/task_e_686654560a848323813abf505852e314