### PR TITLE
Add external playback display to music player

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,4 +46,6 @@ python3 music_player.py
 
 Only basic playback commands (play/stop) are provided and the script falls back
 on commands like `afplay` or `aplay` depending on your platform.
+If you have `playerctl` on Linux or AppleScript support on macOS, the player
+also displays the track currently playing in other music applications.
 


### PR DESCRIPTION
## Summary
- extend music_player to query other players using `playerctl` or AppleScript
- show now playing info from another player in the UI
- mention the feature in the README

## Testing
- `python3 -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_6866559a6760832392da2b7b3998c8da