### PR TITLE
Simplify Tkinter UI theme

### DIFF
--- a/countdown.py
+++ b/countdown.py
@@ -1,5 +1,6 @@
 import tkinter as tk
 from tkinter import messagebox
+from ui_utils import apply_simple_style
 
 class CountdownApp:
     def __init__(self, master):
@@ -18,6 +19,9 @@ class CountdownApp:
         self.remaining = 0
         self.running = False
         self.timer_id = None
+
+        # Apply a minimal style to match the other tools
+        apply_simple_style(master)
 
     def format_time(self, secs):
         m, s = divmod(secs, 60)

--- a/music_player.py
+++ b/music_player.py
@@ -5,6 +5,7 @@ import subprocess
 import tkinter as tk
 from tkinter import filedialog, messagebox
 import shutil
+from ui_utils import apply_simple_style
 
 
 def read_id3v1_tags(path):
@@ -110,6 +111,9 @@ class MusicPlayerApp:
 
         self.update_id = self.update_external()
         self.master.bind('<Destroy>', self._on_destroy)
+
+        # Apply a minimal style for a consistent look
+        apply_simple_style(master)
 
 
     def apply_theme(self, bg: str, fg: str):

--- a/pomodoro.py
+++ b/pomodoro.py
@@ -4,6 +4,7 @@ import tkinter as tk
 from tkinter import messagebox
 from music_player import MusicPlayerApp
 from datetime import date
+from ui_utils import apply_simple_style
 
 DATA_FILE = 'pomodoro_data.json'
 
@@ -28,6 +29,9 @@ class CountdownWindow:
         self.remaining = 0
         self.timer_id = None
         self.running = False
+
+        # Apply the repository's simple theme
+        apply_simple_style(self.top)
 
     def apply_theme(self, bg: str, fg: str):
         self.top.config(bg=bg)
@@ -124,6 +128,9 @@ class PomodoroApp:
                                       command=self.open_music_player)
         self.music_button.grid(row=7, column=0, columnspan=3, pady=(5, 0))
 
+        # Apply a minimal style by default
+        apply_simple_style(master)
+
     def load_data(self):
         today = date.today().isoformat()
         if os.path.exists(DATA_FILE):
@@ -169,6 +176,7 @@ class PomodoroApp:
     def open_countdown(self):
         """Open the countdown timer window."""
         win = CountdownWindow(self.master)
+        apply_simple_style(win.top)
         if self.dark_mode_var.get():
             win.apply_theme('#2e2e2e', '#ffffff')
 
@@ -176,6 +184,7 @@ class PomodoroApp:
         """Open the simple music player window."""
         win = tk.Toplevel(self.master)
         player = MusicPlayerApp(win)
+        apply_simple_style(win)
         if self.dark_mode_var.get() and hasattr(player, 'apply_theme'):
             player.apply_theme('#2e2e2e', '#ffffff')
 

--- a/ui_utils.py
+++ b/ui_utils.py
@@ -1,0 +1,27 @@
+# Utility functions for applying a simple, consistent UI theme.
+import tkinter as tk
+
+SIMPLE_BG = '#f8f8f8'
+SIMPLE_FG = '#000000'
+
+
+def apply_simple_style(win: tk.Misc, bg: str = SIMPLE_BG, fg: str = SIMPLE_FG):
+    """Apply a minimal style to the given tkinter window."""
+    try:
+        win.configure(bg=bg)
+    except tk.TclError:
+        pass
+    for child in win.winfo_children():
+        if isinstance(child, (tk.Button, tk.Label, tk.Entry, tk.Checkbutton)):
+            try:
+                child.configure(bg=bg, fg=fg)
+            except tk.TclError:
+                pass
+        if isinstance(child, tk.Entry):
+            try:
+                child.configure(insertbackground=fg)
+            except tk.TclError:
+                pass
+        # Also apply recursively for frames
+        if isinstance(child, (tk.Frame, tk.LabelFrame, tk.Toplevel)):
+            apply_simple_style(child, bg, fg)


### PR DESCRIPTION
## Summary
- add `ui_utils` module with `apply_simple_style`
- apply simplified style in `countdown.py`, `music_player.py`, and `pomodoro.py`
- automatically style countdown and music windows opened from the Pomodoro app

## Testing
- `python3 -m py_compile countdown.py music_player.py pomodoro.py ui_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_68665ac50c44832384b823d3524da59e