### PR TITLE
Handle invalid work input on reset and include music button in theme

### DIFF
--- a/pomodoro.py
+++ b/pomodoro.py
@@ -160,7 +160,8 @@ class PomodoroApp:
         widgets = [
             self.work_label, self.break_label, self.time_label,
             self.start_button, self.pause_button, self.reset_button,
-            self.count_label, self.dark_mode_check, self.countdown_button
+            self.count_label, self.dark_mode_check, self.countdown_button,
+            self.music_button
         ]
         for w in widgets:
             w.config(bg=bg, fg=fg)
@@ -226,7 +227,12 @@ class PomodoroApp:
         self.start_button.config(text='Start', state='normal')
         self.pause_button.config(state='disabled')
         self.reset_button.config(state='disabled')
-        self.time_label.config(text=self.format_time(int(float(self.work_var.get()) * 60)))
+        try:
+            work_seconds = int(float(self.work_var.get()) * 60)
+        except ValueError:
+            work_seconds = self.work_seconds
+            messagebox.showwarning('Invalid input', 'Work minutes must be a number. Using the last valid value.')
+        self.time_label.config(text=self.format_time(work_seconds))
 
     def countdown(self):
         self.time_label.config(text=self.format_time(self.remaining_seconds))


### PR DESCRIPTION
### Motivation
- Prevent the app from crashing when the user clicks `Reset` after entering a non-numeric value for work minutes by providing a safe fallback.  
- Inform the user when their input is invalid so they understand why a fallback value is used.  
- Ensure the music player button receives the same applied theme as the rest of the UI for a consistent look.  

### Description
- Update `reset` to parse `work_var` inside a `try/except` and fall back to `self.work_seconds` on `ValueError`.  
- Show a `messagebox.showwarning` when `work_var` cannot be parsed to notify the user of the invalid input.  
- Add `self.music_button` to the widget list in `apply_theme` so it is styled alongside other controls.  

### Testing
- No automated tests were executed for this change.  
- The change is limited to UI flow and input validation and does not add or modify automated test cases.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d19717d788323be8a7eb947d43aeb)