### PR TITLE
Add Apple-inspired glass UI styling and restyle Pomodoro + Music Player

### DIFF
--- a/ui_utils.py
+++ b/ui_utils.py
@@ -4,6 +4,29 @@ import tkinter as tk
 SIMPLE_BG = '#f8f8f8'
 SIMPLE_FG = '#000000'
 
+# Apple-inspired glassmorphism palette
+GLASS_LIGHT_THEME = {
+    'window': '#e5e9f2',
+    'card': '#f9fbff',
+    'text': '#1c2635',
+    'muted_text': '#546071',
+    'accent': '#4f7cff',
+    'accent_active': '#2f5ee8',
+    'entry_bg': '#eef2fb',
+    'border': '#d9e2f3'
+}
+
+GLASS_DARK_THEME = {
+    'window': '#12151c',
+    'card': '#1b202c',
+    'text': '#f5f7ff',
+    'muted_text': '#c8cedd',
+    'accent': '#6c8dff',
+    'accent_active': '#4f74f5',
+    'entry_bg': '#12151c',
+    'border': '#2a3040'
+}
+
 
 def apply_simple_style(win: tk.Misc, bg: str = SIMPLE_BG, fg: str = SIMPLE_FG):
     """Apply a minimal style to the given tkinter window."""
@@ -25,3 +48,110 @@ def apply_simple_style(win: tk.Misc, bg: str = SIMPLE_BG, fg: str = SIMPLE_FG):
         # Also apply recursively for frames
         if isinstance(child, (tk.Frame, tk.LabelFrame, tk.Toplevel)):
             apply_simple_style(child, bg, fg)
+
+
+def apply_glass_style(win: tk.Misc, theme: dict = None):
+    """Apply a modern glass-inspired background to a window."""
+    theme = theme or GLASS_LIGHT_THEME
+    try:
+        win.configure(bg=theme['window'])
+    except tk.TclError:
+        pass
+
+
+def create_glass_card(parent: tk.Misc, theme: dict = None) -> tk.Frame:
+    """Create a lightly frosted container for grouping controls."""
+    theme = theme or GLASS_LIGHT_THEME
+    frame = tk.Frame(
+        parent,
+        bg=theme['card'],
+        bd=0,
+        highlightthickness=1,
+        highlightbackground=theme['border'],
+        highlightcolor=theme['border']
+    )
+    return frame
+
+
+def style_heading(label: tk.Label, theme: dict = None):
+    theme = theme or GLASS_LIGHT_THEME
+    label.configure(
+        bg=theme['card'],
+        fg=theme['text'],
+        font=('SF Pro Display', 18, 'bold')
+    )
+
+
+def style_subtext(label: tk.Label, theme: dict = None):
+    theme = theme or GLASS_LIGHT_THEME
+    label.configure(
+        bg=theme['card'],
+        fg=theme['muted_text'],
+        font=('SF Pro Text', 11)
+    )
+
+
+def style_stat_label(label: tk.Label, theme: dict = None):
+    theme = theme or GLASS_LIGHT_THEME
+    label.configure(
+        bg=theme['card'],
+        fg=theme['text'],
+        font=('SF Pro Display', 14, 'bold')
+    )
+
+
+def style_body(label: tk.Label, theme: dict = None):
+    theme = theme or GLASS_LIGHT_THEME
+    label.configure(
+        bg=theme['card'],
+        fg=theme['text'],
+        font=('SF Pro Text', 12)
+    )
+
+
+def style_entry(entry: tk.Entry, theme: dict = None):
+    theme = theme or GLASS_LIGHT_THEME
+    entry.configure(
+        bg=theme['entry_bg'],
+        fg=theme['text'],
+        insertbackground=theme['text'],
+        relief='flat',
+        font=('SF Pro Text', 12),
+        highlightthickness=1,
+        highlightbackground=theme['border'],
+        highlightcolor=theme['accent'],
+        bd=0
+    )
+
+
+def style_switch(check: tk.Checkbutton, theme: dict = None):
+    theme = theme or GLASS_LIGHT_THEME
+    check.configure(
+        bg=theme['card'],
+        fg=theme['muted_text'],
+        selectcolor=theme['card'],
+        activebackground=theme['card'],
+        activeforeground=theme['text'],
+        font=('SF Pro Text', 11, 'bold')
+    )
+
+
+def style_glass_button(button: tk.Button, theme: dict = None, primary: bool = True):
+    theme = theme or GLASS_LIGHT_THEME
+    bg = theme['accent'] if primary else theme['entry_bg']
+    fg = '#ffffff' if primary else theme['text']
+    active_bg = theme['accent_active'] if primary else theme['border']
+    button.configure(
+        bg=bg,
+        fg=fg,
+        activebackground=active_bg,
+        activeforeground=fg,
+        relief='flat',
+        bd=0,
+        padx=12,
+        pady=8,
+        font=('SF Pro Display', 11, 'bold'),
+        cursor='hand2',
+        highlightthickness=0,
+        disabledforeground=theme['muted_text']
+    )


### PR DESCRIPTION
### Motivation
- Introduce a modern, Apple-like glassmorphism visual language to improve the app's aesthetics and consistency.
- Provide reusable styling utilities so multiple windows (Pomodoro, Countdown, Music Player) can share the same look and dark-mode behavior.
- Make the countdown and music player UIs more polished and easier to extend with consistent components.

### Description
- Added new themes and helper functions in `ui_utils.py`: `GLASS_LIGHT_THEME`, `GLASS_DARK_THEME`, `apply_glass_style`, `create_glass_card`, and a set of `style_*` helpers plus `style_glass_button` for consistent controls.
- Restyled the main Pomodoro UI in `pomodoro.py` to use glass cards, updated layout, headings, entry/button styles, dark-mode toggling between `GLASS_LIGHT_THEME` and `GLASS_DARK_THEME`, and child-window tracking for consistent theming.
- Reworked the `CountdownWindow` to be a glass-styled card with its own `apply_theme` and safe close callback, and updated the music player (`music_player.py`) to use the same theme utilities and visual structure.
- Kept backwards-compatible behavior of timers and music playback while replacing the previous minimal styling plumbing with the new theme API.

### Testing
- Compiled the package with `python -m compileall .` and the compilation completed successfully.
- Imported the `pomodoro` module in a quick smoke test (`import pomodoro`) which succeeded without errors.
- No additional automated unit tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d200f9d10832388cf14b7f7fc030f)