### PR TITLE
Fix syntax error in pomodoro count label f-string

### DIFF
--- a/pomodoro.py
+++ b/pomodoro.py
@@ -245,7 +245,7 @@ class PomodoroApp:
         self.reset_button.grid(row=6, column=2, sticky='ew', pady=(0, 6))
 
         # --- Progress / Status ---
-        self.count_label = tk.Label(self.controls_panel.content, text=f\"Today's pomodoros: {self.data['count']}\")
+        self.count_label = tk.Label(self.controls_panel.content, text=f"Today's pomodoros: {self.data['count']}")
         self.count_label.grid(row=7, column=0, columnspan=3, sticky='w', pady=(4, 4))
 
         # --- Toggles ---


### PR DESCRIPTION
### Motivation
- The UI initialization raised a `SyntaxError` due to an invalid escape sequence in the pomodoro count label f-string. 
- The application needs a properly-quoted string so the label can be created at runtime without parsing errors.

### Description
- Fixed the label creation in `pomodoro.py` by replacing the escaped-quote variant with a correctly quoted f-string: `text=f"Today's pomodoros: {self.data['count']}` -> `text=f"Today's pomodoros: {self.data['count']}`.
- The change is localized to the `self.count_label` instantiation and does not alter layout or behavior beyond removing the syntax error.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e22f6093c8323a466b985dd5dadef)