### PR TITLE
Fix GlassPanel canvas.lower usage to avoid TclError

### DIFF
--- a/ui_utils.py
+++ b/ui_utils.py
@@ -148,7 +148,7 @@ class GlassPanel(tk.Frame):
         self.canvas.place(relwidth=1, relheight=1)
         self.content = tk.Frame(self, bg=self._surface_color())
         self.content.pack(padx=self.padding, pady=self.padding, fill='both', expand=True)
-        self.canvas.lower(self.content)
+        self.canvas.lower()
 
         self.bind('<Configure>', self._on_configure)
 
@@ -228,7 +228,7 @@ class GlassPanel(tk.Frame):
                 width=1
             )
 
-        self.canvas.lower(self.content)
+        self.canvas.lower()
 
 
 def style_card_frame(frame: tk.Frame, theme: dict = None, variant: str = 'base'):


### PR DESCRIPTION
### Motivation
- Initialization and redraw of `GlassPanel` raised a `_tkinter.TclError: invalid boolean operator in tag search expression` when calling `canvas.lower` with a widget argument. 
- Passing the `tk.Frame` widget into `canvas.lower` produced an invalid tag expression in the underlying Tk call. 
- The change aims to avoid that invalid search expression and prevent crashes during window creation and resize handling. 

### Description
- Replace calls to `self.canvas.lower(self.content)` with `self.canvas.lower()` in `ui_utils.py` to lower the canvas without passing a widget tag. 
- The modification occurs in the `GlassPanel.__init__` and at the end of `GlassPanel._draw`. 
- This ensures the drawing canvas is placed behind the content without constructing an invalid tag lookup.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e25b7851c8323bc50d882d5ea0872)