### PR TITLE
Fix GlassPanel canvas stacking to avoid TclError

### DIFF
--- a/ui_utils.py
+++ b/ui_utils.py
@@ -148,7 +148,7 @@ class GlassPanel(tk.Frame):
         self.canvas.place(relwidth=1, relheight=1)
         self.content = tk.Frame(self, bg=self._surface_color())
         self.content.pack(padx=self.padding, pady=self.padding, fill='both', expand=True)
-        self.canvas.lower()
+        self._lower_canvas()
 
         self.bind('<Configure>', self._on_configure)
 
@@ -228,7 +228,13 @@ class GlassPanel(tk.Frame):
                 width=1
             )
 
-        self.canvas.lower()
+        self._lower_canvas()
+
+    def _lower_canvas(self):
+        try:
+            self.canvas.tk.call('lower', self.canvas._w, self.content._w)
+        except tk.TclError:
+            pass
 
 
 def style_card_frame(frame: tk.Frame, theme: dict = None, variant: str = 'base'):


### PR DESCRIPTION
### Motivation
- Initializing or redrawing `GlassPanel` could raise `_tkinter.TclError: invalid boolean operator in tag search expression` when calling `self.canvas.lower()` with a widget argument. 
- The failure occurs during canvas tag/layer operations and breaks UI startup or redraws for glass panels. 
- Ensure the canvas is stacked underneath the content reliably without invoking tag-based lowering that can fail. 

### Description
- Replaced direct `self.canvas.lower()` calls with a safe helper method `_lower_canvas`. 
- Implemented `_lower_canvas` to call the Tk interpreter via `self.canvas.tk.call('lower', self.canvas._w, self.content._w)` inside a `try/except` that catches `tk.TclError`. 
- Updated calls in `GlassPanel.__init__` and at the end of `_draw` to use `_lower_canvas` so stacking is applied safely after initialization and redraws. 
- Changes are contained in `ui_utils.py` and preserve previous behavior when no error occurs. 

### Testing
- No automated tests were run for this change. 
- The fix was implemented and committed to the repository (`ui_utils.py`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e26c48f508323b1c1199876f36de6)