### PR TITLE
Bump version to 0.4.2 and archive 0.4.1 release note

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository contains a simple Pomodoro desktop application written in Python
 
 ## Version status
 
-- **Current version:** 0.4.1 beta — Liquid Glass UI redesign and contrast polish.
+- **Current version:** 0.4.2 fix — Liquid Glass UI redesign and contrast polish.
 - **Update history:** see `history_versions/` for archived notes.
 
 ## Changelog (short)

--- a/history_versions/README.md
+++ b/history_versions/README.md
@@ -2,3 +2,6 @@
 
 ## 0.3.0 Beta
 - Prior feature-complete release before the liquid glass redesign.
+
+## 0.4.1 Beta
+- Liquid Glass UI redesign and contrast polish.


### PR DESCRIPTION
### Motivation
- Update the published release label to `0.4.2 fix` so the README reflects the latest patch release.
- Preserve the previous `0.4.1` notes by moving them into the history log for traceability.
- Keep repository metadata accurate ahead of the planned `0.5.0` UI design pass.

### Description
- Updated the `README.md` current version line from `0.4.1 beta` to `0.4.2 fix`.
- Added a `0.4.1 Beta` entry to `history_versions/README.md` with the short changelog note.
- This is a documentation-only change and does not modify application source code or behavior.

### Testing
- No automated tests were run because this change only updates documentation and should not affect runtime.
- CI was not required for this docs-only update.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e28b440008323ad22dd82b35d032c)