### PR TITLE
Fix Tauri build context and backend resource path resolution

### DIFF
--- a/frontend/src-tauri/build.rs
+++ b/frontend/src-tauri/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    tauri_build::build()
+}


### PR DESCRIPTION
### Motivation
- Resolve compile failures caused by `tauri::generate_context!()` being unavailable at build time without a `build.rs`/`OUT_DIR`.
- Adapt to the `tauri::api::path::resource_dir` usage that now requires `package_info` and `env` to compute the packaged resource directory.
- Ensure the backend `app.py` path is found both in dev mode and in packaged builds and that restarts use the same resolved path.
- Avoid regenerating the Tauri context multiple times during startup.

### Description
- Add `frontend/src-tauri/build.rs` with `tauri_build::build()` to provide the generated Tauri context at build time.
- Thread `resource_dir: Option<PathBuf>` through `BackendProcess::spawn`, `BackendState`, and `locate_backend_script` so the packaged resource directory is used when locating `backend/app.py`.
- Change `locate_backend_script` to accept the passed `resource_dir` instead of calling `tauri::api::path::resource_dir()` directly.
- Initialize the Tauri context once in `main` via `tauri::generate_context!()`, compute `resource_dir` with `tauri::api::path::resource_dir(context.package_info(), context.env())`, pass it to `BackendState::new(resource_dir)`, and call `.run(context)`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e563c65e48323a705cd856477206b)