### PR TITLE
Add standalone CountdownTimer Svelte component

### DIFF
--- a/frontend/src/lib/CountdownTimer.svelte
+++ b/frontend/src/lib/CountdownTimer.svelte
@@ -1,0 +1,87 @@
+<script>
+  import { onDestroy } from 'svelte';
+
+  export let duration = 25 * 60;
+
+  let remainingSeconds = duration;
+  let intervalId = null;
+
+  const formatTime = (totalSeconds) => {
+    const minutes = Math.floor(totalSeconds / 60);
+    const seconds = totalSeconds % 60;
+
+    return `${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`;
+  };
+
+  const tick = () => {
+    if (remainingSeconds <= 0) {
+      remainingSeconds = 0;
+      pauseCountdown();
+      return;
+    }
+
+    remainingSeconds -= 1;
+
+    if (remainingSeconds <= 0) {
+      remainingSeconds = 0;
+      pauseCountdown();
+    }
+  };
+
+  function startCountdown() {
+    if (intervalId !== null) {
+      return;
+    }
+
+    if (remainingSeconds <= 0) {
+      remainingSeconds = 0;
+    }
+
+    intervalId = setInterval(tick, 1000);
+  }
+
+  function pauseCountdown() {
+    if (intervalId === null) {
+      return;
+    }
+
+    clearInterval(intervalId);
+    intervalId = null;
+  }
+
+  function resetCountdown() {
+    pauseCountdown();
+    remainingSeconds = duration;
+  }
+
+  onDestroy(() => {
+    pauseCountdown();
+  });
+</script>
+
+<div class="countdown-timer">
+  <div class="countdown-display">{formatTime(remainingSeconds)}</div>
+  <div class="countdown-actions">
+    <button type="button" on:click={startCountdown}>Start</button>
+    <button type="button" on:click={pauseCountdown}>Pause</button>
+    <button type="button" on:click={resetCountdown}>Reset</button>
+  </div>
+</div>
+
+<style>
+  .countdown-timer {
+    display: grid;
+    gap: 0.75rem;
+  }
+
+  .countdown-display {
+    font-size: 2rem;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .countdown-actions {
+    display: flex;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+  }
+</style>


### PR DESCRIPTION
### Motivation
- Provide a new, independent countdown timer implementation without modifying the pre-existing timer code.  
- Offer a straightforward, reusable UI component that can be used alongside the existing timer.  
- Ensure the new timer implements plain interval-driven countdown semantics with explicit start/pause/reset controls.

### Description
- Added a new Svelte component at `frontend/src/lib/CountdownTimer.svelte` that implements a fresh countdown timer.  
- The component exposes the functions `startCountdown()`, `pauseCountdown()`, and `resetCountdown()` exactly as required.  
- Uses `setInterval` to decrement seconds once per second, renders time in `mm:ss` format, and stops/clears the interval when reaching `00:00`.  
- The change does not modify or reuse any existing timer code and lives entirely in its own module (`CountdownTimer.svelte`).

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f7c19cb248323b829694be6453d7a)