### PR TITLE
Add MusicPlayer Svelte component for background audio control

### DIFF
--- a/frontend/src/lib/MusicPlayer.svelte
+++ b/frontend/src/lib/MusicPlayer.svelte
@@ -1,0 +1,53 @@
+<script lang="ts">
+  import { onDestroy } from 'svelte';
+
+  export let src = '/assets/sounds/focus.mp3';
+
+  let audio: HTMLAudioElement | null = null;
+  let volume = 1;
+
+  const ensureAudio = () => {
+    if (!audio) {
+      audio = new Audio(src);
+      audio.loop = true;
+      audio.volume = volume;
+    }
+    if (audio.src !== src) {
+      audio.src = src;
+    }
+  };
+
+  export const play = () => {
+    ensureAudio();
+    void audio?.play();
+  };
+
+  export const pause = () => {
+    audio?.pause();
+  };
+
+  export const stop = () => {
+    if (!audio) {
+      return;
+    }
+    audio.pause();
+    audio.currentTime = 0;
+  };
+
+  export const setVolume = (value: number) => {
+    const clamped = Math.min(1, Math.max(0, value));
+    volume = clamped;
+    if (audio) {
+      audio.volume = clamped;
+    }
+  };
+
+  onDestroy(() => {
+    if (audio) {
+      audio.pause();
+      audio.src = '';
+      audio.load();
+      audio = null;
+    }
+  });
+</script>


### PR DESCRIPTION
### Motivation
- Provide background music/sound playback logic for the app without adding any audio files or changing existing timer code.
- Implement a reusable `MusicPlayer` module that other UI components can call to control ambient audio by path only.
- Use browser audio APIs to keep playback implementation lightweight and platform-compatible.
- Ensure audio playback supports looping and respects a normalized volume range.

### Description
- Add `frontend/src/lib/MusicPlayer.svelte` which implements playback logic using `HTMLAudioElement` and a default `src` of `/assets/sounds/focus.mp3`.
- Export `play()`, `pause()`, `stop()`, and `setVolume(value: number)` functions and enable `loop` by default.
- Clamp volume values to the `0.0–1.0` range and reset `currentTime` to `0` when `stop()` is called.
- Clean up and unload audio in `onDestroy` to avoid leaked resources.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f7c70f1a8832394c9159466bfaab8)