### PR TITLE
Add dark mode with CSS variables, toggle, and persisted preference

### DIFF
--- a/frontend/src/App.module.css
+++ b/frontend/src/App.module.css
@@ -1,23 +1,112 @@
 :root {
   color-scheme: light;
   font-family: 'SF Pro Display', 'Inter', system-ui, -apple-system, sans-serif;
+  --app-bg-start: #e7f0ff;
+  --app-bg-mid: #d0e1ff;
+  --app-bg-end: #b7cdfa;
+  --app-text: #0c1b2a;
+  --kicker-text: rgba(12, 27, 42, 0.55);
+  --subtitle-text: rgba(12, 27, 42, 0.62);
+  --window-bg: rgba(255, 255, 255, 0.55);
+  --window-shadow: 0 24px 80px rgba(15, 34, 66, 0.18);
+  --window-border: rgba(255, 255, 255, 0.6);
+  --status-bg: rgba(255, 255, 255, 0.6);
+  --status-border: rgba(255, 255, 255, 0.8);
+  --status-text: rgba(12, 27, 42, 0.7);
+  --timer-card-bg: linear-gradient(
+    135deg,
+    rgba(255, 255, 255, 0.75),
+    rgba(255, 255, 255, 0.35)
+  );
+  --timer-card-border: rgba(255, 255, 255, 0.6);
+  --timer-card-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+  --timer-meta-text: rgba(12, 27, 42, 0.6);
+  --primary-bg: rgba(30, 77, 179, 0.85);
+  --primary-text: #ffffff;
+  --primary-border: rgba(30, 77, 179, 0.65);
+  --secondary-bg: rgba(255, 255, 255, 0.65);
+  --secondary-text: #1a2b3a;
+  --secondary-border: rgba(255, 255, 255, 0.8);
+  --ghost-bg: transparent;
+  --ghost-text: rgba(12, 27, 42, 0.7);
+  --ghost-border: rgba(12, 27, 42, 0.15);
+  --glass-bg: rgba(255, 255, 255, 0.6);
+  --glass-border: rgba(255, 255, 255, 0.7);
+  --card-body-text: rgba(12, 27, 42, 0.72);
+  --form-row-text: rgba(12, 27, 42, 0.72);
+  --input-border: rgba(12, 27, 42, 0.12);
+  --input-bg: rgba(255, 255, 255, 0.8);
+  --input-text: #0c1b2a;
+  --card-note-text: rgba(12, 27, 42, 0.5);
+  --toggle-bg: rgba(255, 255, 255, 0.4);
+  --toggle-border: rgba(12, 27, 42, 0.2);
+  --toggle-text: rgba(12, 27, 42, 0.75);
+}
+
+:global(html[data-theme='dark']) {
+  color-scheme: dark;
+  --app-bg-start: #0b1321;
+  --app-bg-mid: #0f1b30;
+  --app-bg-end: #14243f;
+  --app-text: #e6edf7;
+  --kicker-text: rgba(230, 237, 247, 0.6);
+  --subtitle-text: rgba(230, 237, 247, 0.72);
+  --window-bg: rgba(16, 24, 40, 0.72);
+  --window-shadow: 0 24px 80px rgba(6, 10, 18, 0.55);
+  --window-border: rgba(148, 180, 230, 0.18);
+  --status-bg: rgba(12, 20, 34, 0.65);
+  --status-border: rgba(148, 180, 230, 0.22);
+  --status-text: rgba(230, 237, 247, 0.72);
+  --timer-card-bg: linear-gradient(
+    135deg,
+    rgba(20, 30, 48, 0.85),
+    rgba(12, 18, 30, 0.65)
+  );
+  --timer-card-border: rgba(148, 180, 230, 0.2);
+  --timer-card-shadow: inset 0 1px 0 rgba(230, 237, 247, 0.08);
+  --timer-meta-text: rgba(230, 237, 247, 0.64);
+  --primary-bg: rgba(77, 123, 234, 0.9);
+  --primary-text: #f8fbff;
+  --primary-border: rgba(77, 123, 234, 0.72);
+  --secondary-bg: rgba(15, 24, 40, 0.7);
+  --secondary-text: rgba(230, 237, 247, 0.82);
+  --secondary-border: rgba(148, 180, 230, 0.2);
+  --ghost-bg: transparent;
+  --ghost-text: rgba(230, 237, 247, 0.7);
+  --ghost-border: rgba(230, 237, 247, 0.16);
+  --glass-bg: rgba(18, 28, 46, 0.7);
+  --glass-border: rgba(148, 180, 230, 0.2);
+  --card-body-text: rgba(230, 237, 247, 0.74);
+  --form-row-text: rgba(230, 237, 247, 0.74);
+  --input-border: rgba(148, 180, 230, 0.24);
+  --input-bg: rgba(9, 15, 26, 0.85);
+  --input-text: #e6edf7;
+  --card-note-text: rgba(230, 237, 247, 0.5);
+  --toggle-bg: rgba(9, 15, 26, 0.6);
+  --toggle-border: rgba(230, 237, 247, 0.2);
+  --toggle-text: rgba(230, 237, 247, 0.8);
 }
 
 .app {
   min-height: 100vh;
   display: grid;
   place-items: center;
-  background: radial-gradient(circle at top left, #e7f0ff, #d0e1ff 45%, #b7cdfa);
-  color: #0c1b2a;
+  background: radial-gradient(
+    circle at top left,
+    var(--app-bg-start),
+    var(--app-bg-mid) 45%,
+    var(--app-bg-end)
+  );
+  color: var(--app-text);
 }
 
 .window {
   width: min(920px, 92vw);
   padding: 32px;
   border-radius: 28px;
-  background: rgba(255, 255, 255, 0.55);
-  box-shadow: 0 24px 80px rgba(15, 34, 66, 0.18);
-  border: 1px solid rgba(255, 255, 255, 0.6);
+  background: var(--window-bg);
+  box-shadow: var(--window-shadow);
+  border: 1px solid var(--window-border);
   backdrop-filter: blur(28px);
 }
 
@@ -29,11 +118,17 @@
   margin-bottom: 28px;
 }
 
+.headerActions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
 .kicker {
   text-transform: uppercase;
   letter-spacing: 0.24em;
   font-size: 12px;
-  color: rgba(12, 27, 42, 0.55);
+  color: var(--kicker-text);
   margin: 0 0 6px;
 }
 
@@ -45,24 +140,34 @@
 
 .subtitle {
   margin: 8px 0 0;
-  color: rgba(12, 27, 42, 0.62);
+  color: var(--subtitle-text);
 }
 
 .statusPill {
   padding: 8px 16px;
   border-radius: 999px;
-  background: rgba(255, 255, 255, 0.6);
-  border: 1px solid rgba(255, 255, 255, 0.8);
+  background: var(--status-bg);
+  border: 1px solid var(--status-border);
   font-size: 13px;
-  color: rgba(12, 27, 42, 0.7);
+  color: var(--status-text);
+}
+
+.themeToggle {
+  border-radius: 999px;
+  padding: 8px 16px;
+  font-size: 13px;
+  border: 1px solid var(--toggle-border);
+  background: var(--toggle-bg);
+  color: var(--toggle-text);
+  cursor: pointer;
 }
 
 .timerCard {
   border-radius: 24px;
   padding: 24px;
-  background: linear-gradient(135deg, rgba(255, 255, 255, 0.75), rgba(255, 255, 255, 0.35));
-  border: 1px solid rgba(255, 255, 255, 0.6);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+  background: var(--timer-card-bg);
+  border: 1px solid var(--timer-card-border);
+  box-shadow: var(--timer-card-shadow);
   margin-bottom: 24px;
 }
 
@@ -70,7 +175,7 @@
   display: flex;
   justify-content: space-between;
   font-size: 14px;
-  color: rgba(12, 27, 42, 0.6);
+  color: var(--timer-meta-text);
 }
 
 .timerLabel,
@@ -104,21 +209,21 @@
 }
 
 .primaryButton {
-  background: rgba(30, 77, 179, 0.85);
-  color: #fff;
-  border-color: rgba(30, 77, 179, 0.65);
+  background: var(--primary-bg);
+  color: var(--primary-text);
+  border-color: var(--primary-border);
 }
 
 .secondaryButton {
-  background: rgba(255, 255, 255, 0.65);
-  color: #1a2b3a;
-  border-color: rgba(255, 255, 255, 0.8);
+  background: var(--secondary-bg);
+  color: var(--secondary-text);
+  border-color: var(--secondary-border);
 }
 
 .ghostButton {
-  background: transparent;
-  color: rgba(12, 27, 42, 0.7);
-  border-color: rgba(12, 27, 42, 0.15);
+  background: var(--ghost-bg);
+  color: var(--ghost-text);
+  border-color: var(--ghost-border);
 }
 
 .grid {
@@ -130,8 +235,8 @@
 .glassCard {
   padding: 18px;
   border-radius: 20px;
-  background: rgba(255, 255, 255, 0.6);
-  border: 1px solid rgba(255, 255, 255, 0.7);
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-border);
 }
 
 .cardTitle {
@@ -143,7 +248,7 @@
   display: grid;
   gap: 12px;
   font-size: 14px;
-  color: rgba(12, 27, 42, 0.72);
+  color: var(--card-body-text);
 }
 
 .formRow {
@@ -151,21 +256,21 @@
   flex-direction: column;
   gap: 6px;
   font-size: 13px;
-  color: rgba(12, 27, 42, 0.72);
+  color: var(--form-row-text);
 }
 
 .input,
 .select {
   border-radius: 12px;
-  border: 1px solid rgba(12, 27, 42, 0.12);
+  border: 1px solid var(--input-border);
   padding: 8px 10px;
   font-size: 14px;
-  background: rgba(255, 255, 255, 0.8);
-  color: #0c1b2a;
+  background: var(--input-bg);
+  color: var(--input-text);
 }
 
 .cardNote {
   margin: 12px 0 0;
   font-size: 12px;
-  color: rgba(12, 27, 42, 0.5);
+  color: var(--card-note-text);
 }


### PR DESCRIPTION
### Motivation
- Provide a dark theme option implemented without changing layout or component markup and using CSS variables for full color switching.
- Respect the system `prefers-color-scheme` by default while letting users manually override and persist their choice.
- Ensure instant UI updates when switching themes and remove hardcoded colors from components.

### Description
- Introduced CSS theme variables in `frontend/src/App.module.css` and added a dark override under `:global(html[data-theme='dark'])`, and refactored all color usages to consume these variables.
- Added a global theme state and helpers in `frontend/src/App.svelte` including `theme`, `applyTheme`, `setTheme`, and `toggleTheme`, and wired a header toggle button (`.themeToggle`) to switch themes.
- Implemented persistence using `localStorage` with the key `theme` and initialization logic in `onMount` that falls back to `window.matchMedia('(prefers-color-scheme: dark)')` when no stored preference exists.
- Files changed: `frontend/src/App.module.css` (variables + dark rules + variable usage) and `frontend/src/App.svelte` (theme state, toggle, storage, system-pref listener), with no structural/layout changes to components.

### Testing
- Started the dev server with `npm run dev` and confirmed the app served successfully on the Vite dev URL.
- Ran an automated Playwright script that loaded the app, clicked the theme toggle, and captured a screenshot showing the dark theme applied, which completed successfully.
- No unit tests were modified or required for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f7cae63c88323baf28b15cdf92da4)