### PR TITLE
Render countdown timer and music player in App.svelte

### DIFF
--- a/frontend/src/App.module.css
+++ b/frontend/src/App.module.css
@@ -251,6 +251,12 @@
   color: var(--card-body-text);
 }
 
+.mediaControls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
 .formRow {
   display: flex;
   flex-direction: column;

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -12,6 +12,8 @@
   let remainingSeconds = totalSeconds;
   let running = false;
   let intervalId: ReturnType<typeof setInterval> | null = null;
+  let audioRef: HTMLAudioElement | null = null;
+  let audioVolume = 0.6;
   let theme: Theme = 'light';
   let preferSystemTheme = true;
   let systemThemeMedia: MediaQueryList | null = null;
@@ -68,6 +70,34 @@
     remainingSeconds = totalSeconds;
   };
 
+  const playAudio = () => {
+    audioRef?.play();
+  };
+
+  const pauseAudio = () => {
+    audioRef?.pause();
+  };
+
+  const stopAudio = () => {
+    if (!audioRef) {
+      return;
+    }
+    audioRef.pause();
+    audioRef.currentTime = 0;
+  };
+
+  const updateAudioVolume = (value: number) => {
+    audioVolume = value;
+    if (audioRef) {
+      audioRef.volume = value;
+    }
+  };
+
+  const handleVolumeInput = (event: Event) => {
+    const target = event.currentTarget as HTMLInputElement;
+    updateAudioVolume(parseFloat(target.value));
+  };
+
   const applyTheme = (value: Theme) => {
     theme = value;
     document.documentElement.dataset.theme = value;
@@ -104,6 +134,8 @@
     };
 
     systemThemeMedia.addEventListener('change', handleSystemThemeChange);
+    updateAudioVolume(audioVolume);
+    startTimer();
 
     return () => {
       pauseTimer();
@@ -157,6 +189,43 @@
 
     <!-- SETTINGS + STATS GRID -->
     <section class={styles.grid}>
+
+      <!-- MUSIC PLAYER CARD -->
+      <div class={styles.glassCard}>
+        <h2 class={styles.cardTitle}>Focus music</h2>
+
+        <div class={styles.cardBody}>
+          <p>Play a background track to stay in the zone.</p>
+
+          <div class={styles.mediaControls}>
+            <button class={styles.primaryButton} type="button" on:click={playAudio}>
+              Play
+            </button>
+            <button class={styles.secondaryButton} type="button" on:click={pauseAudio}>
+              Pause
+            </button>
+            <button class={styles.ghostButton} type="button" on:click={stopAudio}>
+              Stop
+            </button>
+          </div>
+
+          <label class={styles.formRow}>
+            <span>Volume</span>
+            <input
+              class={styles.input}
+              type="range"
+              min="0"
+              max="1"
+              step="0.01"
+              value={audioVolume}
+              on:input={handleVolumeInput}
+            />
+          </label>
+        </div>
+
+        <p class={styles.cardNote}>Audio source: /assets/sounds/focus.mp3</p>
+        <audio bind:this={audioRef} src="/assets/sounds/focus.mp3" />
+      </div>
 
       <!-- PRESETS CARD -->
       <div class={styles.glassCard}>


### PR DESCRIPTION
### Motivation
- Ensure the countdown timer and a music player are visibly rendered in the main application UI on first launch.  
- Timer must display in mm:ss, decrement every second, and be prominent in the main view.  
- Music player must be visible immediately and provide Play/Pause/Stop and volume controls wired to logic.  
- Keep UI changes confined to the main view and reuse existing styles where possible.

### Description
- Modified `frontend/src/App.svelte` to add an `audio` element bound to `audioRef`, new audio control functions (`playAudio`, `pauseAudio`, `stopAudio`, `updateAudioVolume`), a volume input handler, and to call `startTimer()` on mount so the timer is visible and ticking immediately.  
- Added a visible music player card to the main grid in `App.svelte` containing Play/Pause/Stop buttons and a volume slider that updates the bound `<audio>` element.  
- Updated `frontend/src/App.module.css` with a `.mediaControls` rule to layout the media buttons consistent with existing button styles.  
- Left existing timer UI in place but ensured it starts automatically on mount and continues to decrement each second until reaching `00:00`.

### Testing
- Started the dev server with `npm run dev` and confirmed Vite reported the server as ready, which succeeded.  
- Ran a Playwright script to load `http://127.0.0.1:4173` and capture a screenshot of the app, which completed successfully and shows the timer and music player UI.  
- Fixed a pre-transform syntax issue during development and verified the app reloads successfully after the fix.  
- No automated unit tests exist for these UI changes; verification was performed via the dev server and the Playwright screenshot above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f7ed023e88323addf62578c69e74b)