### PR TITLE
Relocate Music Player & Countdown into single “More Functions” panel

### DIFF
--- a/frontend/src/App.module.css
+++ b/frontend/src/App.module.css
@@ -232,50 +232,6 @@
   gap: 18px;
 }
 
-.moreFunctionsSection {
-  display: flex;
-  justify-content: flex-end;
-  margin-top: 18px;
-}
-
-.moreFunctionsButton {
-  border-radius: 999px;
-  padding: 8px 18px;
-  font-size: 13px;
-  border: 1px solid var(--secondary-border);
-  background: var(--secondary-bg);
-  color: var(--secondary-text);
-  cursor: pointer;
-}
-
-.moreFunctionsPanel {
-  margin-top: 16px;
-}
-
-.moreFunctionsHeader {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
-  gap: 12px;
-  margin-bottom: 12px;
-}
-
-.moreFunctionsSubtitle {
-  margin: 6px 0 0;
-  font-size: 13px;
-  color: var(--card-note-text);
-}
-
-.moreFunctionsClose {
-  border-radius: 999px;
-  padding: 6px 14px;
-  font-size: 12px;
-  border: 1px solid var(--ghost-border);
-  background: var(--ghost-bg);
-  color: var(--ghost-text);
-  cursor: pointer;
-}
-
 .glassCard {
   padding: 18px;
   border-radius: 20px;
@@ -340,11 +296,16 @@
   background: var(--toggle-bg);
   color: var(--toggle-text);
   cursor: pointer;
+  position: fixed;
+  right: 24px;
+  bottom: 24px;
+  z-index: 10;
 }
 
 .moreFunctionsPanel {
   display: grid;
   gap: 12px;
+  margin-top: 16px;
 }
 
 .moreFunctionsItem {
@@ -358,28 +319,10 @@
   font-weight: 600;
 }
 
-/* More Functions – shared panel styles */
-
-.moreFunctionsPanel {
-  border-radius: 16px;
-  border: 1px solid var(--glass-border);
-  padding: 12px;
-  background: rgba(255, 255, 255, 0.35);
-}
-
-.moreFunctionsSummary {
-  cursor: pointer;
-  font-size: 14px;
-  font-weight: 600;
-  color: var(--card-body-text);
-  list-style: none;
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-
-.moreFunctionsSummary::-webkit-details-marker {
-  display: none;
+.moreFunctionsNote {
+  margin: 4px 0 0;
+  font-size: 13px;
+  color: var(--card-note-text);
 }
 
 /* Music player */
@@ -406,39 +349,3 @@
   color: var(--card-body-text);
 }
 
-/* Dark mode */
-
-:global(html[data-theme='dark']) .moreFunctionsPanel {
-  background: rgba(12, 18, 30, 0.6);
-}
-
-
-.moreFunctionsSummary::-webkit-details-marker {
-  display: none;
-}
-
-.fileInput {
-  display: none;
-}
-
-.audioControls {
-  display: grid;
-  gap: 12px;
-  margin-top: 12px;
-}
-
-.audioButtonRow {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 10px;
-}
-
-.playbackStatus {
-  margin: 0;
-  font-size: 13px;
-  color: var(--card-body-text);
-}
-
-:global(html[data-theme='dark']) .moreFunctionsPanel {
-  background: rgba(12, 18, 30, 0.6);
-}

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -130,7 +130,6 @@
     }
     return settings.longBreakMinutes;
   };
-  let showMoreFunctions = false;
 
   const formatSeconds = (seconds: number) => {
     const mins = Math.floor(seconds / 60);
@@ -443,55 +442,6 @@
         <p class={styles.cardNote}>Timer updates every second while running.</p>
       </div>
 
-      <div class={styles.glassCard}>
-        <h2 class={styles.cardTitle}>More Functions</h2>
-
-        <details class={styles.moreFunctionsPanel} open>
-          <summary class={styles.moreFunctionsSummary}>Music player</summary>
-
-          <div class={styles.cardBody}>
-            <input
-              class={styles.fileInput}
-              type="file"
-              accept="audio/*"
-              bind:this={fileInput}
-              on:change={handleAudioFileChange}
-            />
-
-            <div class={styles.audioControls}>
-              <button class={styles.secondaryButton} type="button" on:click={selectAudioFile}>
-                Select Audio File
-              </button>
-
-              <div class={styles.audioButtonRow}>
-                <button class={styles.primaryButton} type="button" on:click={playAudio}>
-                  Play
-                </button>
-                <button class={styles.secondaryButton} type="button" on:click={pauseAudio}>
-                  Pause
-                </button>
-                <button class={styles.ghostButton} type="button" on:click={stopAudio}>
-                  Stop
-                </button>
-              </div>
-
-              <label class={styles.formRow}>
-                <span>Volume ({volume.toFixed(2)})</span>
-                <input
-                  class={styles.input}
-                  type="range"
-                  min="0"
-                  max="1"
-                  step="0.01"
-                  bind:value={volume}
-                />
-              </label>
-
-              <p class={styles.playbackStatus}>Status: {playbackStatus}</p>
-            </div>
-          </div>
-        </details>
-      </div>
     </section>
 
     <section class={styles.moreFunctions}>
@@ -499,8 +449,9 @@
         class={styles.moreFunctionsToggle}
         type="button"
         on:click={toggleMoreFunctions}
+        aria-expanded={moreFunctionsOpen}
       >
-        {moreFunctionsOpen ? 'Hide More Functions' : 'More Functions'}
+        More Functions
       </button>
 
       {#if moreFunctionsOpen}
@@ -508,6 +459,55 @@
           <div class={styles.glassCard}>
             <h2 class={styles.cardTitle}>More Functions</h2>
             <div class={styles.cardBody}>
+              <div class={styles.moreFunctionsItem}>
+                <div>
+                  <p class={styles.moreFunctionsLabel}>Music player</p>
+                  <p class={styles.moreFunctionsNote}>
+                    Pick a local track to play while you focus.
+                  </p>
+                </div>
+                <div>
+                  <input
+                    class={styles.fileInput}
+                    type="file"
+                    accept="audio/*"
+                    bind:this={fileInput}
+                    on:change={handleAudioFileChange}
+                  />
+
+                  <div class={styles.audioControls}>
+                    <button class={styles.secondaryButton} type="button" on:click={selectAudioFile}>
+                      Select Audio File
+                    </button>
+
+                    <div class={styles.audioButtonRow}>
+                      <button class={styles.primaryButton} type="button" on:click={playAudio}>
+                        Play
+                      </button>
+                      <button class={styles.secondaryButton} type="button" on:click={pauseAudio}>
+                        Pause
+                      </button>
+                      <button class={styles.ghostButton} type="button" on:click={stopAudio}>
+                        Stop
+                      </button>
+                    </div>
+
+                    <label class={styles.formRow}>
+                      <span>Volume ({volume.toFixed(2)})</span>
+                      <input
+                        class={styles.input}
+                        type="range"
+                        min="0"
+                        max="1"
+                        step="0.01"
+                        bind:value={volume}
+                      />
+                    </label>
+
+                    <p class={styles.playbackStatus}>Status: {playbackStatus}</p>
+                  </div>
+                </div>
+              </div>
               <div class={styles.moreFunctionsItem}>
                 <div>
                   <p class={styles.moreFunctionsLabel}>Countdown timer</p>
@@ -522,43 +522,5 @@
         </div>
       {/if}
     </section>
-    <div class={styles.moreFunctionsSection}>
-      <button
-        class={styles.moreFunctionsButton}
-        type="button"
-        aria-expanded={showMoreFunctions}
-        aria-controls="more-functions-panel"
-        on:click={() => (showMoreFunctions = true)}
-      >
-        More Functions
-      </button>
-    </div>
-
-    {#if showMoreFunctions}
-      <section
-        id="more-functions-panel"
-        class={`${styles.glassCard} ${styles.moreFunctionsPanel}`}
-      >
-        <div class={styles.moreFunctionsHeader}>
-          <div>
-            <h2 class={styles.cardTitle}>More functions</h2>
-            <p class={styles.moreFunctionsSubtitle}>
-              Future tools like music, analytics, and shortcuts will appear here.
-            </p>
-          </div>
-          <button
-            class={styles.moreFunctionsClose}
-            type="button"
-            on:click={() => (showMoreFunctions = false)}
-          >
-            Close
-          </button>
-        </div>
-
-        <div class={styles.cardBody}>
-          <p>Placeholder panel ready for upcoming features.</p>
-        </div>
-      </section>
-    {/if}
   </section>
 </main>


### PR DESCRIPTION
### Motivation
- Keep the main Pomodoro page focused on the core timer and move all extra tools into the secondary panel labeled `More Functions`.
- Ensure there is exactly one entry point (`More Functions`) located at the bottom-right and remove duplicate floating/inline controls.
- Prevent the Music Player and Countdown Timer from appearing in the main grid and ensure the countdown runs independently from Pomodoro state.
- Preserve existing audio controls and dark mode styling while avoiding new toggle systems or `<details>` for page navigation.

### Description
- Removed the inline music player `details` block from the main grid and moved the full Music Player UI into the secondary panel alongside the `CountdownTimer` component.
- Removed the duplicate placeholder/secondary panel and the extra `More Functions` floating button and consolidated to a single toggle button `More Functions` that is fixed bottom-right and toggles `moreFunctionsOpen`.
- Updated `frontend/src/App.module.css` to adjust the panel and toggle layout (positioned `.moreFunctionsToggle` fixed at bottom-right), removed unused panel/button classes, and added `.moreFunctionsNote` while preserving music player styles like `.audioControls` and `.playbackStatus`.
- Did not change Pomodoro core timer logic or audio behavior (file select, play/pause/stop, volume, playback status) and added `aria-expanded` on the toggle for accessibility.

### Testing
- Launched the dev server with `npm run dev` and the server started successfully (Vite ready and listening). 
- Ran a Playwright script that navigated to the app, clicked the `More Functions` button, and captured a screenshot showing the Music Player and Countdown Timer inside the secondary panel, which succeeded. 
- No unit tests were added or run as this change was UI/layout focused. 
- All automated steps above completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f96fa3eec83239e6e3a339ddea2ee)