### PR TITLE
Fix More Functions button alignment

### DIFF
--- a/frontend/src/App.module.css
+++ b/frontend/src/App.module.css
@@ -285,10 +285,10 @@
   margin-top: 24px;
   display: grid;
   gap: 16px;
+  justify-items: end;
 }
 
 .moreFunctionsToggle {
-  align-self: flex-start;
   border-radius: 999px;
   padding: 10px 20px;
   font-size: 14px;
@@ -296,10 +296,6 @@
   background: var(--toggle-bg);
   color: var(--toggle-text);
   cursor: pointer;
-  position: fixed;
-  right: 24px;
-  bottom: 24px;
-  z-index: 10;
 }
 
 .moreFunctionsPanel {
@@ -348,4 +344,3 @@
   font-size: 13px;
   color: var(--card-body-text);
 }
-


### PR DESCRIPTION
### Motivation
- The More Functions toggle was positioned fixed and could be clipped or misaligned on smaller windows, causing a button display bug.
- The intent is to keep the toggle visually anchored to the More Functions section and avoid overlap with other UI elements.

### Description
- Updated `frontend/src/App.module.css` to remove the fixed positioning from `.moreFunctionsToggle` and dropped `align-self: flex-start`.
- Added `justify-items: end` to the `.moreFunctions` grid to right-align the toggle inside its section instead of using absolute positioning.
- This keeps the button positioned by the layout grid, preventing clipping and improving responsiveness.

### Testing
- Ran `npm install` in `frontend` which completed successfully.
- Launched the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` and Vite started successfully.
- Executed a Playwright script that loaded the app and produced a screenshot at `artifacts/more-functions-button.png`, confirming the button placement visually.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695fa5897e3083238f91e58e80c6c777)