### PR TITLE
Add customizable, persistent duration input to standalone countdown timer

### DIFF
--- a/frontend/src/lib/CountdownTimer.svelte
+++ b/frontend/src/lib/CountdownTimer.svelte
@@ -1,9 +1,15 @@
 <script>
-  import { onDestroy } from 'svelte';
+  import { onDestroy, onMount } from 'svelte';
 
-  export let duration = 25 * 60;
+  const STORAGE_KEY = 'countdown_duration_minutes';
+  const MINUTES_MIN = 1;
+  const MINUTES_MAX = 180;
 
-  let remainingSeconds = duration;
+  export let defaultMinutes = 25;
+
+  let durationMinutes = defaultMinutes;
+  let durationInput = String(defaultMinutes);
+  let remainingSeconds = durationMinutes * 60;
   let intervalId = null;
 
   const formatTime = (totalSeconds) => {
@@ -11,6 +17,33 @@
     const seconds = totalSeconds % 60;
 
     return `${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`;
+  };
+
+  const clampMinutes = (value) => {
+    if (!Number.isFinite(value)) {
+      return defaultMinutes;
+    }
+
+    return Math.min(MINUTES_MAX, Math.max(MINUTES_MIN, Math.round(value)));
+  };
+
+  const applyDurationMinutes = (value) => {
+    durationMinutes = clampMinutes(value);
+    durationInput = String(durationMinutes);
+    pauseCountdown();
+    remainingSeconds = durationMinutes * 60;
+    localStorage.setItem(STORAGE_KEY, String(durationMinutes));
+  };
+
+  const handleDurationChange = (event) => {
+    const nextValue = Number.parseInt(event.currentTarget.value, 10);
+
+    if (!Number.isFinite(nextValue)) {
+      durationInput = String(durationMinutes);
+      return;
+    }
+
+    applyDurationMinutes(nextValue);
   };
 
   const tick = () => {
@@ -51,8 +84,20 @@
 
   function resetCountdown() {
     pauseCountdown();
-    remainingSeconds = duration;
+    remainingSeconds = durationMinutes * 60;
   }
+
+  onMount(() => {
+    const storedValue = localStorage.getItem(STORAGE_KEY);
+    if (storedValue) {
+      const parsedValue = Number.parseInt(storedValue, 10);
+      if (Number.isFinite(parsedValue)) {
+        durationMinutes = clampMinutes(parsedValue);
+        durationInput = String(durationMinutes);
+        remainingSeconds = durationMinutes * 60;
+      }
+    }
+  });
 
   onDestroy(() => {
     pauseCountdown();
@@ -60,6 +105,20 @@
 </script>
 
 <div class="countdown-timer">
+  <label class="duration-input">
+    <span>Duration (minutes)</span>
+    <input
+      type="number"
+      min={MINUTES_MIN}
+      max={MINUTES_MAX}
+      step="1"
+      inputmode="numeric"
+      class="duration-field"
+      bind:value={durationInput}
+      on:change={handleDurationChange}
+      aria-label="Countdown duration in minutes"
+    />
+  </label>
   <div class="countdown-display">{formatTime(remainingSeconds)}</div>
   <div class="countdown-actions">
     <button type="button" on:click={startCountdown}>Start</button>
@@ -72,6 +131,31 @@
   .countdown-timer {
     display: grid;
     gap: 0.75rem;
+  }
+
+  .duration-input {
+    display: grid;
+    gap: 0.35rem;
+    font-size: 0.85rem;
+    color: rgba(255, 255, 255, 0.7);
+  }
+
+  :global(body.light) .duration-input {
+    color: rgba(15, 23, 42, 0.7);
+  }
+
+  .duration-field {
+    width: 100%;
+    padding: 0.5rem 0.75rem;
+    border-radius: 0.75rem;
+    border: 1px solid rgba(255, 255, 255, 0.18);
+    background: rgba(255, 255, 255, 0.08);
+    color: inherit;
+  }
+
+  :global(body.light) .duration-field {
+    border: 1px solid rgba(15, 23, 42, 0.12);
+    background: rgba(15, 23, 42, 0.04);
   }
 
   .countdown-display {


### PR DESCRIPTION
### Motivation

- The standalone countdown was hard-coded to 25 minutes and needed to be user-configurable without touching the Pomodoro logic.  
- The selected duration must persist across app restarts and be clamped to a safe range.  
- Changing the duration should reset the countdown and must not auto-start it or affect Pomodoro sessions.  
- The control should fit the app's existing macOS-style glass UI and work in light/dark modes.

### Description

- Added a minutes input above the timer and bound it to `durationMinutes` with a visible `durationInput` field in `frontend/src/lib/CountdownTimer.svelte`.  
- Enforced whole-number clamping between `1` and `180` minutes and defaulted to `25` minutes via `clampMinutes` and `defaultMinutes`.  
- Changing the duration pauses and resets the countdown to the selected duration, `Reset` restores the currently selected duration, and changes are saved to `localStorage` under the key `countdown_duration_minutes`.  
- Styling for the input reuses the app's glass-style visual language and includes light/dark adjustments using `:global(body.light)` selectors.

### Testing

- Launched the dev server with `npm run dev` to verify the frontend builds and serves, and the server started successfully.  
- Ran a Playwright smoke script that opens the app, opens the More Functions panel, and captured a screenshot of the countdown UI, which completed successfully.  
- No unit test suite was modified or executed as part of this change.  
- Manual UI interaction was exercised via the automated browser script to confirm the new input renders and persists across reloads.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6961d48e8c948323aa22fec482a45e8d)