### PR TITLE
Improve countdown duration input styling

### DIFF
--- a/frontend/src/lib/CountdownTimer.svelte
+++ b/frontend/src/lib/CountdownTimer.svelte
@@ -137,25 +137,26 @@
     display: grid;
     gap: 0.35rem;
     font-size: 0.85rem;
-    color: rgba(255, 255, 255, 0.7);
-  }
-
-  :global(body.light) .duration-input {
-    color: rgba(15, 23, 42, 0.7);
+    color: var(--form-row-text);
   }
 
   .duration-field {
     width: 100%;
-    padding: 0.5rem 0.75rem;
+    padding: 0.5rem 2.25rem 0.5rem 0.75rem;
     border-radius: 0.75rem;
-    border: 1px solid rgba(255, 255, 255, 0.18);
-    background: rgba(255, 255, 255, 0.08);
-    color: inherit;
+    border: 1px solid var(--input-border);
+    background: var(--input-bg);
+    color: var(--input-text);
+    font-size: 0.875rem;
+    line-height: 1.2;
+    min-height: 40px;
+    box-sizing: border-box;
+    caret-color: var(--input-text);
   }
 
-  :global(body.light) .duration-field {
-    border: 1px solid rgba(15, 23, 42, 0.12);
-    background: rgba(15, 23, 42, 0.04);
+  .duration-field::placeholder {
+    color: var(--card-note-text);
+    opacity: 1;
   }
 
   .countdown-display {


### PR DESCRIPTION
### Motivation
- Fix low-contrast, misaligned, and visually inconsistent appearance of the countdown `Duration (minutes)` input without changing any timer logic or state handling.
- Ensure entered text is clearly readable in both light and dark themes and that placeholder text is visually distinct from entered text.
- Vertically center numeric value and ensure padding prevents text overlap with native spinner controls.
- Align the component with existing theme variables for consistent app-wide appearance.

### Description
- Updated `frontend/src/lib/CountdownTimer.svelte` to use theme variables for label and input colors by switching to `var(--form-row-text)`, `var(--input-border)`, `var(--input-bg)`, and `var(--input-text)`.
- Adjusted input padding to `padding: 0.5rem 2.25rem 0.5rem 0.75rem` and added `min-height: 40px`, `line-height: 1.2`, and `box-sizing: border-box` to improve vertical centering and spacing from spinner arrows.
- Increased input font size and set `caret-color` for better contrast, and added placeholder styling using `--card-note-text` with `opacity: 1` to keep it muted but readable.
- This is a styling-only change and does not touch countdown logic, state handling, or component behavior.

### Testing
- Started the frontend dev server with `npm run dev` to load the updated UI, which launched successfully before being cancelled. 
- Attempted an automated UI check using Playwright to fill the duration input and capture a screenshot, but the Chromium run crashed (SIGSEGV) and Firefox timed out, so the screenshot step failed. 
- `npm install` completed successfully in the frontend to ensure dependencies were available for local UI checks. 
- No unit or integration test suite was modified or run because this is a UI-only styling fix.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6961d820dc0c83239133133cf6fb4595)