### PR TITLE
Add macOS system media controls and Web Audio white-noise focus sound

### DIFF
--- a/frontend/src/App.module.css
+++ b/frontend/src/App.module.css
@@ -335,6 +335,15 @@
   margin-top: 12px;
 }
 
+.audioSection {
+  display: grid;
+  gap: 8px;
+  padding: 12px;
+  border-radius: 16px;
+  border: 1px solid var(--glass-border);
+  background: var(--glass-bg);
+}
+
 .audioButtonRow {
   display: flex;
   flex-wrap: wrap;

--- a/frontend/src/lib/systemMedia.ts
+++ b/frontend/src/lib/systemMedia.ts
@@ -1,0 +1,20 @@
+import { invoke } from '@tauri-apps/api/tauri';
+
+export type SystemMediaState = {
+  available: boolean;
+  title: string;
+  artist: string | null;
+  source: string;
+  isPlaying: boolean;
+  supportsPlayPause: boolean;
+  supportsNext: boolean;
+  supportsPrevious: boolean;
+};
+
+export async function getSystemMediaState(): Promise<SystemMediaState> {
+  return invoke('get_system_media_state');
+}
+
+export async function controlSystemMedia(action: 'play_pause' | 'next' | 'previous') {
+  return invoke('control_system_media', { action });
+}


### PR DESCRIPTION
### Motivation

- Surface and control macOS system media so the app can detect external playback and send transport commands without taking ownership.  
- Provide an in-app, loopable focus sound (white noise) generated at runtime to avoid shipping binary audio assets.  
- Make audio behavior Pomodoro-aware so music/focus sound can be paused on breaks and resumed afterward.  
- Present audio-source status and simple transport controls in the More Functions UI for clearer audio priority.

### Description

- Add AppleScript-backed Tauri commands `get_system_media_state` and `control_system_media` in `frontend/src-tauri/src/main.rs` and expose them via the `invoke_handler`.  
- Add a small frontend IPC helper `frontend/src/lib/systemMedia.ts` and poll system media state from `App.svelte` every 4s, plus UI transport buttons that call `controlSystemMedia`.  
- Replace the bundled `white-noise.wav` with a generated Web Audio implementation in `frontend/src/App.svelte` using `AudioContext`, `AudioBufferSourceNode`, and `GainNode`, and add `start/pause/stop` focus sound behavior plus shared volume handling.  
- Add pause-on-break logic and resume handling in `App.svelte` (capturing `resumeAudioState`), add UI elements and a `pauseMusicOnBreak` setting, and add styling `.audioSection` in `frontend/src/App.module.css`; remove the binary asset `frontend/src/assets/white-noise.wav`.

### Testing

- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962052d50dc8323bb9d94ace5aedee1)