### PR TITLE
Unify audio playback controls and add source selector

### DIFF
--- a/frontend/src/App.module.css
+++ b/frontend/src/App.module.css
@@ -211,6 +211,14 @@
   cursor: pointer;
 }
 
+.primaryButton:disabled,
+.secondaryButton:disabled,
+.ghostButton:disabled,
+.sourceToggleButton:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
 .primaryButton {
   background: var(--primary-bg);
   color: var(--primary-text);
@@ -324,6 +332,41 @@
   margin-top: 12px;
 }
 
+.audioSourceSelector {
+  display: grid;
+  gap: 10px;
+  padding: 12px;
+  border-radius: 16px;
+  border: 1px solid var(--glass-border);
+  background: var(--glass-bg);
+}
+
+.sourceToggleRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.sourceToggleButton {
+  border-radius: 999px;
+  border: 1px solid var(--glass-border);
+  background: var(--glass-bg);
+  padding: 8px 14px;
+  font-size: 13px;
+  color: var(--card-body-text);
+  cursor: pointer;
+}
+
+.sourceToggleButton:hover {
+  border-color: var(--secondary-border);
+}
+
+.sourceToggleActive {
+  background: var(--secondary-bg);
+  border-color: var(--secondary-border);
+  color: var(--secondary-text);
+}
+
 .audioSection {
   display: grid;
   gap: 8px;
@@ -333,10 +376,31 @@
   background: var(--glass-bg);
 }
 
+.sourceTitle {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--app-text);
+}
+
 .audioButtonRow {
   display: flex;
   flex-wrap: wrap;
   gap: 10px;
+}
+
+.playbackBar {
+  display: grid;
+  gap: 12px;
+  padding: 12px;
+  border-radius: 16px;
+  border: 1px solid var(--glass-border);
+  background: var(--glass-bg);
+}
+
+.audioMeta {
+  display: grid;
+  gap: 4px;
 }
 
 .playbackStatus {


### PR DESCRIPTION
### Motivation
- Provide a single playback area that controls the currently active audio source to remove redundant UI and behavior.
- Let users explicitly switch between `system` media, local audio files, and built-in focus sounds so only one source is active at a time.
- Ensure playback controls adapt to the capabilities of the selected source (previous/next/play/pause/stop/volume).
- Improve clarity of system media metadata and keep local/focus playback behavior consistent and predictable.

### Description
- Replace per-source controls with a unified source selector and playback bar implemented in `frontend/src/App.svelte` and styled in `frontend/src/App.module.css`.
- Introduce `activeAudioSource`, `setActiveAudioSource`, `stopActiveSource`, `handlePlayPause`, and `handleStop` and refactor playback state variables (`localAudioStatus`, `localAudioName`, `systemMediaTitle`, `focusSoundSelection`, etc.).
- Update the Music tab UI to show per-source metadata, allow file selection for local audio, choose focus sound type, and reuse the same Play/Pause/Stop/Previous buttons with adaptive enabled/disabled logic.
- Add new CSS for the source selector, playback bar, source buttons, and disabled button appearance in `frontend/src/App.module.css`.

### Testing
- Started the dev server with `npm run dev` and confirmed Vite served the app on port 4173 (succeeded).
- Executed an automated Playwright smoke script that navigated to the app, opened the Music tab, and saved a screenshot `artifacts/unified-audio-controls.png` (succeeded).
- No unit tests were changed for this UI-focused change.
- All automated checks exercised during the rollout completed without failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696228e0b7548323bed6e26eacc1ec3e)