### PR TITLE
Fix countdown ring artifacts and polish countdown UI sizing

### DIFF
--- a/frontend/src/App.module.css
+++ b/frontend/src/App.module.css
@@ -259,6 +259,40 @@
   gap: 24px;
 }
 
+.countdownView {
+  display: grid;
+  gap: 32px;
+  justify-items: center;
+  text-align: center;
+  padding: 10px 0 24px;
+}
+
+.countdownHeader {
+  display: grid;
+  gap: 6px;
+  max-width: 420px;
+}
+
+.countdownKicker {
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.32em;
+  font-size: 11px;
+  color: var(--kicker-text);
+}
+
+.countdownTitle {
+  margin: 0;
+  font-size: 28px;
+  font-weight: 600;
+}
+
+.countdownNote {
+  margin: 0;
+  font-size: 13px;
+  color: var(--card-note-text);
+}
+
 .glassCard {
   padding: 18px;
   border-radius: 20px;

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -1139,13 +1139,16 @@
         id="view-countdown"
         aria-hidden={activeTab !== 'countdown'}
       >
-        <div class={styles.glassCard}>
-          <h2 class={styles.cardTitle}>Countdown timer</h2>
-          <p class={styles.cardNote}>
-            An optional countdown that runs independently from your Pomodoro session.
-          </p>
+        <section class={styles.countdownView}>
+          <header class={styles.countdownHeader}>
+            <p class={styles.countdownKicker}>Independent timer</p>
+            <h2 class={styles.countdownTitle}>Countdown</h2>
+            <p class={styles.countdownNote}>
+              A lightweight timer for quick focus blocks and short reminders.
+            </p>
+          </header>
           <CountdownTimer />
-        </div>
+        </section>
       </section>
 
     </div>


### PR DESCRIPTION
### Motivation

- Eliminate visual artifacts (black marks) around the SVG progress ring by removing problematic shadows and smoothing stroke ends.  
- Improve usability and accessibility by increasing the size of action buttons and the duration input so they’re easier to tap and read.  
- Center and emphasize the circular countdown ring as the primary visual focus for the timer.  

### Description

- Added a responsive SVG ring to `frontend/src/lib/CountdownTimer.svelte` with `RING_RADIUS`, `RING_CIRCUMFERENCE`, and reactive `progressRatio`/`ringOffset` to drive the progress stroke.  
- Rounded stroke endcaps by setting `stroke-linecap: round` on `.ring-track` and preserved on `.ring-progress`.  
- Removed `filter: drop-shadow(...)` from the progress ring (and its dark-theme variant) to remove shadow artifacts causing black marks.  
- Increased control/input sizing and layout by updating `CountdownTimer.svelte`, `App.svelte`, and `App.module.css` to center the countdown layout and enlarge buttons/inputs (`padding`, `font-size`, and `min-height`).  

### Testing

- Launched the dev server with `npm run dev -- --host 0.0.0.0 --port 4173`, and the Vite server reported ready.  
- Executed a Playwright script that opened the app, selected the `Countdown` tab, and saved a screenshot to `artifacts/countdown.png`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962453d57248323a2f4a14a9c110b67)