### PR TITLE
Center music player header

### DIFF
--- a/frontend/src/App.module.css
+++ b/frontend/src/App.module.css
@@ -356,6 +356,10 @@
 
 /* Music player */
 
+.musicHeader {
+  text-align: center;
+}
+
 .fileInput {
   display: none;
 }

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -971,10 +971,12 @@
         aria-hidden={activeTab !== 'music'}
       >
         <div class={styles.glassCard}>
-          <h2 class={styles.cardTitle}>Music player</h2>
-          <p class={styles.cardNote}>
-            Pick a local track or focus sound to stay in the zone.
-          </p>
+          <div class={styles.musicHeader}>
+            <h2 class={styles.cardTitle}>Music player</h2>
+            <p class={styles.cardNote}>
+              Pick a local track or focus sound to stay in the zone.
+            </p>
+          </div>
           <div class={styles.cardBody}>
             <input
               class={styles.fileInput}


### PR DESCRIPTION
### Motivation

- Align the music player title and note to the center of the music view for improved visual balance.
- Provide a dedicated container to control header layout separately from the card body.

### Description

- Wrap the music header content in a new container `div` with class `musicHeader` in `frontend/src/App.svelte`.
- Add the `.musicHeader { text-align: center; }` rule to `frontend/src/App.module.css` to center the header text.
- Changes touch `frontend/src/App.svelte` and `frontend/src/App.module.css` to implement the layout update.

### Testing

- Started the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` and Vite reported ready successfully.
- Ran an automated Playwright script that navigated to the app, opened the Music view, and captured a screenshot saved to `artifacts/music-center.png`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69624b1e3c1483238d5f4785f8285cb4)