### PR TITLE
Replace main title with logo

### DIFF
--- a/frontend/src/App.module.css
+++ b/frontend/src/App.module.css
@@ -135,10 +135,11 @@
   margin: 0 0 6px;
 }
 
-.title {
-  margin: 0;
-  font-size: 36px;
-  font-weight: 600;
+.logo {
+  width: 120px;
+  height: auto;
+  margin: 4px 0;
+  display: block;
 }
 
 .subtitle {

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -2,6 +2,7 @@
   import { onMount } from 'svelte';
   import CountdownTimer from './lib/CountdownTimer.svelte';
   import { controlSystemMedia, getSystemMediaState, type SystemMediaState } from './lib/systemMedia';
+  import logo from './assets/logo.svg';
   import styles from './App.module.css';
 
   const SETTINGS_STORAGE_KEY = 'pomodoro_settings';
@@ -796,7 +797,7 @@
     <header class={styles.header}>
       <div>
         <p class={styles.kicker}>Pomodoro</p>
-        <h1 class={styles.title}>Stay in flow</h1>
+        <img class={styles.logo} src={logo} alt="Pomodoro logo" />
         <p class={styles.subtitle}>A calm space for focused sessions.</p>
       </div>
 

--- a/frontend/src/assets/logo.svg
+++ b/frontend/src/assets/logo.svg
@@ -1,0 +1,27 @@
+<svg width="256" height="256" viewBox="0 0 256 256" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="topGradient" x1="40" y1="40" x2="216" y2="216" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#cfe3ff" />
+      <stop offset="0.55" stop-color="#a7c7f4" />
+      <stop offset="1" stop-color="#7ea4e8" />
+    </linearGradient>
+    <linearGradient id="middleGradient" x1="32" y1="64" x2="212" y2="236" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#d7e4f5" />
+      <stop offset="0.6" stop-color="#9fb3d6" />
+      <stop offset="1" stop-color="#7f8fb5" />
+    </linearGradient>
+    <linearGradient id="bottomGradient" x1="24" y1="88" x2="220" y2="248" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#c9f1f1" />
+      <stop offset="0.55" stop-color="#90d3dd" />
+      <stop offset="1" stop-color="#61b7cc" />
+    </linearGradient>
+    <filter id="softShadow" x="0" y="0" width="256" height="256" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feDropShadow dx="0" dy="8" stdDeviation="12" flood-color="#6d89b6" flood-opacity="0.2" />
+    </filter>
+  </defs>
+  <rect x="28" y="28" width="200" height="200" rx="36" transform="rotate(45 128 128)" fill="url(#bottomGradient)" opacity="0.9" />
+  <rect x="36" y="16" width="200" height="200" rx="36" transform="rotate(45 128 128)" fill="url(#middleGradient)" opacity="0.85" />
+  <g filter="url(#softShadow)">
+    <rect x="44" y="4" width="200" height="200" rx="38" transform="rotate(45 128 128)" fill="url(#topGradient)" />
+  </g>
+</svg>


### PR DESCRIPTION
### Motivation

- Replace the textual main title with a logo to improve branding and visual identity.
- Keep the header layout and spacing while swapping the `<h1>` for an image so the visual hierarchy is preserved.
- Add a reusable SVG asset so the logo can be referenced across the app.

### Description

- Add the SVG asset at `frontend/src/assets/logo.svg` and import it in `frontend/src/App.svelte` via `import logo from './assets/logo.svg'`.
- Replace the header title element with an image: the `<h1 class={styles.title}>` was replaced by `<img class={styles.logo} src={logo} alt="Pomodoro logo" />`.
- Update `frontend/src/App.module.css` to add a `.logo` rule (width, margin, display) and remove the previous `.title` text styling.

### Testing

- Ran `npm install` in `frontend` which completed successfully.
- Started the dev server with `npm run dev` and Vite reported the server ready (served on the listed local/network URLs).
- Used a Playwright script to open the dev server and capture a screenshot (`artifacts/pomodoro-logo.png`), which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962514b61d88323bd7faee7dfd6dede)