### PR TITLE
Frameless macOS-style title bar with custom traffic lights & frosted glass

### DIFF
--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -13,6 +13,9 @@
     "allowlist": {
       "shell": {
         "all": true
+      },
+      "window": {
+        "all": true
       }
     },
     "bundle": {
@@ -27,7 +30,7 @@
         "height": 720,
         "resizable": true,
         "transparent": true,
-        "decorations": true
+        "decorations": false
       }
     ]
   }

--- a/frontend/src/App.module.css
+++ b/frontend/src/App.module.css
@@ -7,7 +7,11 @@
   --app-text: #0c1b2a;
   --kicker-text: rgba(12, 27, 42, 0.55);
   --subtitle-text: rgba(12, 27, 42, 0.62);
-  --window-bg: rgba(255, 255, 255, 0.55);
+  --window-bg: linear-gradient(
+    135deg,
+    rgba(255, 255, 255, 0.78),
+    rgba(255, 255, 255, 0.62)
+  );
   --window-shadow: 0 24px 80px rgba(15, 34, 66, 0.18);
   --window-border: rgba(255, 255, 255, 0.6);
   --status-bg: rgba(255, 255, 255, 0.6);
@@ -51,7 +55,11 @@
   --app-text: #e6edf7;
   --kicker-text: rgba(230, 237, 247, 0.6);
   --subtitle-text: rgba(230, 237, 247, 0.72);
-  --window-bg: rgba(16, 24, 40, 0.72);
+  --window-bg: linear-gradient(
+    135deg,
+    rgba(22, 32, 52, 0.78),
+    rgba(14, 22, 38, 0.62)
+  );
   --window-shadow: 0 24px 80px rgba(6, 10, 18, 0.55);
   --window-border: rgba(148, 180, 230, 0.18);
   --status-bg: rgba(12, 20, 34, 0.65);
@@ -87,30 +95,110 @@
   --toggle-text: rgba(230, 237, 247, 0.8);
 }
 
+:global(html, body, #app) {
+  margin: 0;
+  padding: 0;
+  height: 100%;
+  width: 100%;
+  background: transparent;
+}
+
+:global(body) {
+  padding-top: 0 !important;
+  padding-bottom: 0 !important;
+}
+
 .app {
-  min-height: 100vh;
-  display: grid;
-  place-items: center;
-  background: radial-gradient(
-    circle at top left,
-    var(--app-bg-start),
-    var(--app-bg-mid) 45%,
-    var(--app-bg-end)
-  );
+  min-height: 100%;
+  display: flex;
+  flex-direction: column;
+  background: var(--window-bg);
+  border-radius: 24px;
+  border: 1px solid var(--window-border);
+  box-shadow: var(--window-shadow);
+  backdrop-filter: blur(32px) saturate(1.2);
+  -webkit-backdrop-filter: blur(32px) saturate(1.2);
+  overflow: hidden;
   color: var(--app-text);
 }
 
 .window {
-  width: min(920px, 92vw);
-  padding: 32px 32px 20px;
-  border-radius: 28px;
-  background: var(--window-bg);
-  box-shadow: var(--window-shadow);
-  border: 1px solid var(--window-border);
-  backdrop-filter: blur(28px);
+  width: 100%;
+  height: 100%;
+  padding: 0 32px 20px;
   display: flex;
   flex-direction: column;
   gap: 24px;
+}
+
+.titleBar {
+  width: 100%;
+  height: 32px;
+  padding: 10px 16px 6px;
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+}
+
+.trafficLights {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.trafficLight {
+  width: 12px;
+  height: 12px;
+  border-radius: 999px;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  position: relative;
+  display: grid;
+  place-items: center;
+  box-shadow: inset 0 0 0 0 transparent;
+  transition: filter 0.15s ease, box-shadow 0.15s ease;
+}
+
+.trafficLight::before {
+  opacity: 0;
+  transition: opacity 0.15s ease;
+  font-size: 8px;
+  line-height: 1;
+  color: rgba(36, 36, 36, 0.7);
+}
+
+.trafficLight:hover {
+  filter: brightness(1.08);
+  box-shadow: inset 0 0 0 0.5px rgba(0, 0, 0, 0.35);
+}
+
+.trafficLight:hover::before {
+  opacity: 0.85;
+}
+
+.trafficLightClose {
+  background: #ff5f57;
+}
+
+.trafficLightClose::before {
+  content: '×';
+}
+
+.trafficLightMinimize {
+  background: #febc2e;
+}
+
+.trafficLightMinimize::before {
+  content: '–';
+}
+
+.trafficLightFullscreen {
+  background: #28c840;
+}
+
+.trafficLightFullscreen::before {
+  content: '+';
 }
 
 .header {

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { onMount } from 'svelte';
+  import { appWindow } from '@tauri-apps/api/window';
   import CountdownTimer from './lib/CountdownTimer.svelte';
   import { controlSystemMedia, getSystemMediaState, type SystemMediaState } from './lib/systemMedia';
   import styles from './App.module.css';
@@ -83,6 +84,18 @@
     focusSound: false,
     localAudio: false,
     systemAudio: false
+  };
+  const closeWindow = () => {
+    appWindow.close();
+  };
+
+  const minimizeWindow = () => {
+    appWindow.minimize();
+  };
+
+  const toggleFullscreen = async () => {
+    const isFullscreen = await appWindow.isFullscreen();
+    await appWindow.setFullscreen(!isFullscreen);
   };
   type AppTab = 'music' | 'pomodoro' | 'countdown';
   const tabs: { id: AppTab; label: string; icon: string; description: string }[] = [
@@ -793,6 +806,31 @@
 
 <main class={styles.app}>
   <section class={styles.window}>
+    <header class={styles.titleBar} data-tauri-drag-region>
+      <div class={styles.trafficLights}>
+        <button
+          class={`${styles.trafficLight} ${styles.trafficLightClose}`}
+          type="button"
+          on:click={closeWindow}
+          aria-label="Close window"
+          data-tauri-drag-region="false"
+        />
+        <button
+          class={`${styles.trafficLight} ${styles.trafficLightMinimize}`}
+          type="button"
+          on:click={minimizeWindow}
+          aria-label="Minimize window"
+          data-tauri-drag-region="false"
+        />
+        <button
+          class={`${styles.trafficLight} ${styles.trafficLightFullscreen}`}
+          type="button"
+          on:click={toggleFullscreen}
+          aria-label="Toggle fullscreen"
+          data-tauri-drag-region="false"
+        />
+      </div>
+    </header>
     <header class={styles.header}>
       <div>
         <p class={styles.kicker}>Pomodoro</p>


### PR DESCRIPTION
### Motivation

- Remove native macOS window chrome and reserved titlebar space to allow UI to start at y = 0.  
- Provide custom macOS-style traffic lights (close/minimize/fullscreen) placed top-left and wired to window actions.  
- Create a half‑transparent frosted glass background using blur + translucency to preserve window shadow and readability.  
- Ensure a precise drag region and eliminate the random top gap caused by default margins or safe-area insets.  

### Description

- Updated Tauri window configuration in `frontend/src-tauri/tauri.conf.json` to use `"decorations": false`, `"transparent": true`, `"resizable": true` and enabled the `window` allowlist (so window APIs can be called).  
- Added a custom title bar and traffic-light buttons in `frontend/src/App.svelte`, imported `appWindow` from `@tauri-apps/api/window`, and implemented `closeWindow()`, `minimizeWindow()`, and `toggleFullscreen()` handlers that call `appWindow` methods.  
- Implemented drag region and safe exclusions by adding a top `header` with `data-tauri-drag-region` and marking each traffic-light button with `data-tauri-drag-region="false"` so traffic lights are clickable and the surrounding area remains draggable.  
- Implemented frosted-glass styling and removed the top gap in `frontend/src/App.module.css` by zeroing global margins/padding (`html`, `body`, `#app`), forcing `padding-top: 0`, using translucent `--window-bg` gradients, and applying `backdrop-filter`/`-webkit-backdrop-filter` and glass variables for cards and the overall layout.  

### Testing

- Started the dev server with `npm run dev -- --host 0.0.0.0 --port 5173`, and Vite reported the site ready (local server started successfully).  
- Attempted a Playwright screenshot to validate layout, but the headless Chromium crashed with a SIGSEGV in this environment so automated visual capture failed.  
- No unit or integration test suite was run as part of this change.  
- Manual inspection is recommended on macOS to confirm native-like spacing, hover states, drag/resize behavior and window shadow are preserved.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69625bbfbb7c8323bcd32c3d404fac80)