### PR TITLE
Enable Tauri system tray config (add iconPath)

### DIFF
--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -20,6 +20,9 @@
       "targets": "all",
       "identifier": "com.pomodoro.app"
     },
+    "systemTray": {
+      "iconPath": "icons/icon.png"
+    },
     "windows": [
       {
         "title": "Pomodoro",


### PR DESCRIPTION
### Motivation
- Ensure the Tauri `system-tray` feature is enabled at build time by declaring a `systemTray` configuration with an icon path. 
- This prevents compile-time gating that caused unresolved imports for `SystemTray`, `SystemTrayEvent`, `SystemTrayMenu`, `SystemTrayMenuItem`, and `SystemTraySubmenu`.

### Description
- Add a `systemTray` section to `frontend/src-tauri/tauri.conf.json` with `"iconPath": "icons/icon.png"` to enable tray support. 
- No source code logic changes were made to Rust files in this PR, only the Tauri configuration was updated.

### Testing
- An attempted `cargo update -p tauri -p tauri-build` was run but failed due to network access errors when fetching crates (download/config index failed). 
- No automated build or test runs completed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696270e105bc8323b7ffb3348044841d)