### PR TITLE
Remove macOS window chrome and top gap; add small drag region

### DIFF
--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -30,7 +30,7 @@
         "height": 720,
         "resizable": true,
         "transparent": true,
-        "decorations": true
+        "decorations": false
       }
     ]
   }

--- a/frontend/src/App.module.css
+++ b/frontend/src/App.module.css
@@ -43,6 +43,16 @@
   --toggle-text: rgba(12, 27, 42, 0.75);
 }
 
+:global(html, body) {
+  margin: 0;
+  padding: 0;
+  height: 100%;
+}
+
+:global(#app) {
+  height: 100%;
+}
+
 :global(html[data-theme='dark']) {
   color-scheme: dark;
   --app-bg-start: #0b1321;
@@ -88,7 +98,8 @@
 }
 
 .app {
-  min-height: 100vh;
+  min-height: 100%;
+  height: 100%;
   display: grid;
   place-items: center;
   background: radial-gradient(
@@ -98,6 +109,15 @@
     var(--app-bg-end)
   );
   color: var(--app-text);
+}
+
+.dragRegion {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 26px;
+  z-index: 10;
 }
 
 .window {

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -968,6 +968,7 @@
 </script>
 
 <main class={styles.app}>
+  <div class={styles.dragRegion} data-tauri-drag-region aria-hidden="true"></div>
   <section class={styles.window}>
     <header class={styles.header}>
       <div>


### PR DESCRIPTION
### Motivation
- Remove the native macOS title bar and traffic lights to eliminate the odd top frame while preserving the exact UI.
- Ensure the app content starts at the very top (y = 0) by removing root margins/gaps without changing visible layout or component structure.
- Restore window dragging after removing the native title bar by adding a minimal draggable region that does not interfere with interactive elements.

### Description
- Updated the Tauri v1 window configuration in `frontend/src-tauri/tauri.conf.json` to set `"decorations": false` while leaving `"transparent"` and `"resizable"` unchanged.
- Added global CSS in `frontend/src/App.module.css` to zero `html`/`body` margins and padding and set `#app` and the root `.app` to fill `height: 100%` so the UI begins at y = 0.
- Introduced a small fixed top drag strip `.dragRegion` in `frontend/src/App.module.css` and inserted `<div class={styles.dragRegion} data-tauri-drag-region aria-hidden="true"></div>` at the very top of `frontend/src/App.svelte` to enable window dragging without affecting UI elements.
- No headers, containers, layout spacing, fonts, or component hierarchy were modified beyond the minimal additions above.

### Testing
- Started the dev server with `npm run dev` and Vite served the application successfully.
- Captured a full-page screenshot via Playwright which completed successfully against the running dev server.
- No unit or CI tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963585d0cc483239a29048a09d5a35c)