### PR TITLE
Restore macOS glass styling for cards

### DIFF
--- a/frontend/src/App.module.css
+++ b/frontend/src/App.module.css
@@ -15,11 +15,11 @@
   --status-text: rgba(12, 27, 42, 0.7);
   --timer-card-bg: linear-gradient(
     135deg,
-    rgba(255, 255, 255, 0.75),
-    rgba(255, 255, 255, 0.35)
+    rgba(255, 255, 255, 0.88),
+    rgba(248, 248, 248, 0.72)
   );
-  --timer-card-border: rgba(255, 255, 255, 0.6);
-  --timer-card-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+  --timer-card-border: rgba(0, 0, 0, 0.08);
+  --timer-card-shadow: 0 18px 40px rgba(0, 0, 0, 0.08);
   --timer-meta-text: rgba(12, 27, 42, 0.6);
   --primary-bg: rgba(30, 77, 179, 0.85);
   --primary-text: #ffffff;
@@ -30,8 +30,9 @@
   --ghost-bg: transparent;
   --ghost-text: rgba(12, 27, 42, 0.7);
   --ghost-border: rgba(12, 27, 42, 0.15);
-  --glass-bg: rgba(255, 255, 255, 0.6);
-  --glass-border: rgba(255, 255, 255, 0.7);
+  --glass-bg: rgba(255, 255, 255, 0.82);
+  --glass-border: rgba(0, 0, 0, 0.08);
+  --glass-shadow: 0 12px 30px rgba(0, 0, 0, 0.08);
   --card-body-text: rgba(12, 27, 42, 0.72);
   --form-row-text: rgba(12, 27, 42, 0.72);
   --input-border: rgba(12, 27, 42, 0.12);
@@ -68,11 +69,11 @@
   --status-text: rgba(230, 237, 247, 0.72);
   --timer-card-bg: linear-gradient(
     135deg,
-    rgba(20, 30, 48, 0.85),
-    rgba(12, 18, 30, 0.65)
+    rgba(28, 28, 32, 0.75),
+    rgba(18, 18, 22, 0.6)
   );
-  --timer-card-border: rgba(148, 180, 230, 0.2);
-  --timer-card-shadow: inset 0 1px 0 rgba(230, 237, 247, 0.08);
+  --timer-card-border: rgba(255, 255, 255, 0.14);
+  --timer-card-shadow: 0 18px 40px rgba(0, 0, 0, 0.45);
   --timer-meta-text: rgba(230, 237, 247, 0.64);
   --primary-bg: rgba(77, 123, 234, 0.9);
   --primary-text: #f8fbff;
@@ -83,8 +84,9 @@
   --ghost-bg: transparent;
   --ghost-text: rgba(230, 237, 247, 0.7);
   --ghost-border: rgba(230, 237, 247, 0.16);
-  --glass-bg: rgba(18, 28, 46, 0.7);
-  --glass-border: rgba(148, 180, 230, 0.2);
+  --glass-bg: rgba(20, 20, 25, 0.7);
+  --glass-border: rgba(255, 255, 255, 0.12);
+  --glass-shadow: 0 12px 30px rgba(0, 0, 0, 0.4);
   --card-body-text: rgba(230, 237, 247, 0.74);
   --form-row-text: rgba(230, 237, 247, 0.74);
   --input-border: rgba(148, 180, 230, 0.24);
@@ -323,6 +325,9 @@
   border-radius: 20px;
   background: var(--glass-bg);
   border: 1px solid var(--glass-border);
+  box-shadow: var(--glass-shadow);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
 }
 
 .cardTitle {
@@ -402,6 +407,7 @@
   border-radius: 16px;
   border: 1px solid var(--glass-border);
   background: var(--glass-bg);
+  box-shadow: var(--glass-shadow);
 }
 
 .sourceToggleRow {
@@ -437,6 +443,7 @@
   border-radius: 16px;
   border: 1px solid var(--glass-border);
   background: var(--glass-bg);
+  box-shadow: var(--glass-shadow);
 }
 
 .sourceTitle {
@@ -459,6 +466,7 @@
   border-radius: 16px;
   border: 1px solid var(--glass-border);
   background: var(--glass-bg);
+  box-shadow: var(--glass-shadow);
 }
 
 .audioMeta {
@@ -490,6 +498,7 @@
   text-align: left;
   color: var(--card-body-text);
   cursor: pointer;
+  box-shadow: var(--glass-shadow);
 }
 
 .templateButton:hover {
@@ -535,6 +544,7 @@
   font-size: 12px;
   color: var(--card-body-text);
   cursor: pointer;
+  box-shadow: var(--glass-shadow);
 }
 
 .templateChip:hover {


### PR DESCRIPTION
### Motivation
- The bottom panels and other card-like containers had become flat white and lost macOS-style glass contrast, so a neutral translucent card treatment was needed.
- Provide a single shared visual style (translucent background, subtle 1px border, soft shadow, light blur) that works in both light and dark modes without changing layout or behavior.
- Keep tints neutral (no blue) and apply the style only to existing card/panel containers and timer surfaces.

### Description
- Changed `frontend/src/App.module.css` to tune shared variables: updated `--timer-card-bg`, `--timer-card-border`, `--timer-card-shadow`, `--glass-bg`, `--glass-border`, and added `--glass-shadow` for both light and dark modes (e.g. `--timer-card-bg: linear-gradient(135deg, rgba(255,255,255,0.88), rgba(248,248,248,0.72));` and `--glass-bg: rgba(255,255,255,0.82);`).
- Applied the new visual treatment to card/panel classes by adding `box-shadow` and a light blur to `.glassCard` and adding `box-shadow` to existing card-like selectors: `.timerCard`, `.glassCard`, `.audioSourceSelector`, `.audioSection`, `.playbackBar`, `.templateButton`, and `.templateChip` (exact CSS examples: `.glassCard { box-shadow: var(--glass-shadow); backdrop-filter: blur(16px); -webkit-backdrop-filter: blur(16px); }`).
- File changed: `frontend/src/App.module.css` (only CSS variables and visual styles were edited; no HTML/class renames, layout, spacing, padding, or timer logic were modified).

### Testing
- Ran `npm install` in `frontend` successfully (no dependency changes required). 
- Launched the dev server with `npm run dev -- --host 0.0.0.0 --port 5173` and it started successfully (Vite ready).
- Captured a UI screenshot via Playwright to verify visual result (screenshot produced).
- No automated unit tests were required or changed for this styling-only update.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69637b7930dc83238fa1f7bf97eb598d)