### PR TITLE
Add neutral macOS-style glass background layer (CSS only)

### DIFF
--- a/frontend/src/App.module.css
+++ b/frontend/src/App.module.css
@@ -4,6 +4,7 @@
   --app-bg-start: #e7f0ff;
   --app-bg-mid: #d0e1ff;
   --app-bg-end: #b7cdfa;
+  --app-glass-bg: rgba(255, 255, 255, 0.55);
   --app-text: #0c1b2a;
   --kicker-text: rgba(12, 27, 42, 0.55);
   --subtitle-text: rgba(12, 27, 42, 0.62);
@@ -58,6 +59,7 @@
   --app-bg-start: rgba(0, 0, 0, 0);
   --app-bg-mid: rgba(0, 0, 0, 0);
   --app-bg-end: rgba(0, 0, 0, 0);
+  --app-glass-bg: rgba(18, 20, 26, 0.55);
   --app-text: #e6edf7;
   --kicker-text: rgba(230, 237, 247, 0.6);
   --subtitle-text: rgba(230, 237, 247, 0.72);
@@ -103,10 +105,24 @@
   height: 100%;
   display: grid;
   place-items: center;
-  background: rgba(255, 255, 255, 0.6);
+  position: relative;
+  background: transparent;
+  color: var(--app-text);
+}
+
+.app::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: var(--app-glass-bg);
   backdrop-filter: blur(30px);
   -webkit-backdrop-filter: blur(30px);
-  color: var(--app-text);
+  z-index: 0;
+}
+
+.app > * {
+  position: relative;
+  z-index: 1;
 }
 
 .dragRegion {


### PR DESCRIPTION
### Motivation
- Restore a neutral, frosted macOS-style glass base layer behind the UI because the window currently appears solid white in light mode and solid black in dark mode. 
- Keep the app window OS-level transparency while adding a subtle backdrop blur layer, not redesigning or modifying existing panels. 

### Description
- Add a single root glass background variable `--app-glass-bg` and apply it via an `::before` pseudo-element on `.app` with `background: var(--app-glass-bg)` and `backdrop-filter: blur(30px)` to create the frosted effect. 
- Change `.app` to `position: relative` and layer the glass behind content using `.app::before { z-index: 0 }` and `.app > * { position: relative; z-index: 1 }` so existing UI stays unchanged and readable. 
- Put light and dark variants of the glass color in `:root` and `:global(html[data-theme='dark'])` using neutral RGBA values and no tint, gradients, or solid fills. 
- All changes are limited to `frontend/src/App.module.css` and no JavaScript or Rust code was modified. 

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69637dbcd8948323970737a55f343d43)