### PR TITLE
Add glass backdrop layer behind UI

### DIFF
--- a/frontend/src/App.module.css
+++ b/frontend/src/App.module.css
@@ -110,9 +110,8 @@
   color: var(--app-text);
 }
 
-.app::before {
-  content: '';
-  position: absolute;
+.glassBackground {
+  position: fixed;
   inset: 0;
   background: var(--app-glass-bg);
   backdrop-filter: blur(30px);
@@ -120,7 +119,7 @@
   z-index: 0;
 }
 
-.app > * {
+.app > :not(.glassBackground) {
   position: relative;
   z-index: 1;
 }

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -968,6 +968,7 @@
 </script>
 
 <main class={styles.app}>
+  <div class={styles.glassBackground} aria-hidden="true"></div>
   <div class={styles.dragRegion} data-tauri-drag-region aria-hidden="true"></div>
   <section class={styles.window}>
     <header class={styles.header}>


### PR DESCRIPTION
### Motivation
- Enable a macOS-style glass effect that blurs the desktop wallpaper behind the transparent Tauri window.  
- The app window is already transparent but the background was appearing flat, so a single backdrop layer is needed to expose and blur the wallpaper.  
- The change must use `backdrop-filter` and a neutral translucent fill for light/dark themes and must sit behind all UI.  
- Avoid touching layout, typography, panels, or Rust/Tauri config.

### Description
- Add a fixed DOM layer by inserting `<div class={styles.glassBackground} aria-hidden="true"></div>` into `frontend/src/App.svelte` to cover the full window.  
- Replace the previous pseudo-element approach with a `.glassBackground` rule in `frontend/src/App.module.css` that sets `background: var(--app-glass-bg)` and both `backdrop-filter` and `-webkit-backdrop-filter`.  
- Ensure correct stacking by making `.app > :not(.glassBackground)` position content above the backdrop so all UI renders on top.  
- No layout, spacing, typography, panel structure, or Rust/Tauri config changes were made.

### Testing
- Started the dev server with `npm run dev` and Vite reported ready, indicating the app served successfully.  
- Captured a screenshot with a headless Playwright script which navigated to the dev server and saved `artifacts/pomodoro-glass-bg.png`, confirming the glass layer renders in the browser.  
- No unit or integration test suites were modified or run for this UI-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69637f9b68c88323ad34ac1bbce55829)