### PR TITLE
Add Rust TimerEngine and macOS native status bar with live monospaced MM:SS title

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,11 +10,11 @@
     "tauri": "tauri"
   },
   "dependencies": {
-    "@tauri-apps/api": "^1.5.0"
+    "@tauri-apps/api": "^2.0.0"
   },
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "^3.0.2",
-    "@tauri-apps/cli": "^1.5.9",
+    "@tauri-apps/cli": "^2.0.0",
     "svelte": "^4.2.9",
     "typescript": "^5.4.5",
     "vite": "^5.2.8"

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -5,15 +5,18 @@ description = "Pomodoro Tauri frontend"
 edition = "2021"
 
 [build-dependencies]
-tauri-build = { version = "1.5", features = [] }
+tauri-build = { version = "2.0", features = [] }
 
 [dependencies]
-tauri = { version = "1.8.3", features = [ "shell-all",
-  "system-tray",
-  "notification"] }
+tauri = { version = "2.9.0", features = [] }
+tauri-plugin-notification = "2.0.0"
 window-vibrancy = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+once_cell = "1.19"
+objc2 = "0.5"
+objc2-foundation = "0.2"
+objc2-app-kit = "0.2"
 
 [features]
 custom-protocol = ["tauri/custom-protocol"]

--- a/frontend/src-tauri/src/status_bar.rs
+++ b/frontend/src-tauri/src/status_bar.rs
@@ -1,0 +1,618 @@
+#[cfg(target_os = "macos")]
+use std::sync::{Arc, Mutex};
+
+#[cfg(target_os = "macos")]
+use objc2::declare::ClassDecl;
+#[cfg(target_os = "macos")]
+use objc2::rc::Id;
+#[cfg(target_os = "macos")]
+use objc2::runtime::{Class, Object, Sel};
+#[cfg(target_os = "macos")]
+use objc2::{class, msg_send, sel, sel_impl};
+#[cfg(target_os = "macos")]
+use objc2_app_kit::{
+    NSAttributedString, NSControlStateValue, NSFont, NSMenu, NSMenuItem, NSStatusBar,
+    NSStatusItem, NSStatusItemLength,
+};
+#[cfg(target_os = "macos")]
+use objc2_foundation::{NSDictionary, NSString};
+#[cfg(target_os = "macos")]
+use once_cell::sync::OnceCell;
+#[cfg(target_os = "macos")]
+use tauri::{AppHandle, Manager};
+
+#[cfg(target_os = "macos")]
+use crate::system_media::{control_media_action, get_system_media_state, SystemMediaState};
+use crate::timer::{FocusSound, PomodoroMode, TimerEngine, TimerSnapshot};
+
+#[cfg(target_os = "macos")]
+static TIMER_ENGINE: OnceCell<Arc<TimerEngine>> = OnceCell::new();
+#[cfg(target_os = "macos")]
+static APP_HANDLE: OnceCell<AppHandle> = OnceCell::new();
+#[cfg(target_os = "macos")]
+static STATUS_BAR: OnceCell<StatusBarController> = OnceCell::new();
+
+#[cfg(target_os = "macos")]
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum MenuMode {
+    PomodoroRunning,
+    BreakRunning,
+    CountdownRunning,
+    Idle,
+}
+
+#[cfg(target_os = "macos")]
+#[derive(Clone, PartialEq, Eq)]
+struct MenuSignature {
+    mode: MenuMode,
+    countdown_running: bool,
+    music_available: bool,
+    music_playing: bool,
+    supports_play_pause: bool,
+    supports_previous: bool,
+    supports_next: bool,
+    focus_sound: FocusSound,
+}
+
+#[cfg(target_os = "macos")]
+pub struct StatusBarController {
+    status_item: Id<NSStatusItem>,
+    menu: Id<NSMenu>,
+    handler: Id<Object>,
+    last_title: Mutex<String>,
+    last_signature: Mutex<Option<MenuSignature>>,
+}
+
+#[cfg(target_os = "macos")]
+#[cfg(target_os = "macos")]
+impl StatusBarController {
+    pub fn new(app: AppHandle, engine: Arc<TimerEngine>) -> Self {
+        let _ = TIMER_ENGINE.set(engine);
+        let _ = APP_HANDLE.set(app);
+        let handler = create_handler();
+        let status_bar = NSStatusBar::system_status_bar();
+        let status_item =
+            unsafe { status_bar.status_item_with_length(NSStatusItemLength::Variable) };
+        let menu = NSMenu::new();
+        unsafe {
+            status_item.set_menu(Some(&menu));
+        }
+        Self {
+            status_item,
+            menu,
+            handler,
+            last_title: Mutex::new(String::new()),
+            last_signature: Mutex::new(None),
+        }
+    }
+
+    pub fn update(&self, snapshot: &TimerSnapshot) {
+        let title = build_title(snapshot);
+        if title != *self.last_title.lock().expect("status title lock") {
+            self.set_title(&title);
+            *self.last_title.lock().expect("status title lock") = title;
+        }
+
+        let media_state = get_system_media_state();
+        let signature = MenuSignature {
+            mode: menu_mode(snapshot),
+            countdown_running: snapshot.countdown.running,
+            music_available: media_state.available,
+            music_playing: media_state.is_playing,
+            supports_play_pause: media_state.supports_play_pause,
+            supports_previous: media_state.supports_previous,
+            supports_next: media_state.supports_next,
+            focus_sound: snapshot.focus_sound,
+        };
+
+        let mut last_signature = self.last_signature.lock().expect("menu signature lock");
+        if last_signature.as_ref() != Some(&signature) {
+        self.rebuild_menu(snapshot, &media_state);
+            *last_signature = Some(signature);
+        }
+    }
+
+    fn set_title(&self, title: &str) {
+        if let Some(button) = unsafe { self.status_item.button() } {
+            let font: Id<NSFont> = unsafe {
+                let font: *mut NSFont = msg_send![class!(NSFont), monospacedDigitSystemFontOfSize: 0.0 weight: 0.0];
+                Id::from_retained_ptr(font)
+            };
+            let ns_title = NSString::from_str(title);
+            let attributes = NSDictionary::from_keys_and_objects(
+                &[NSString::from_str("NSFontAttributeName")],
+                &[font],
+            );
+            let attributed =
+                NSAttributedString::alloc().init_with_string_attributes(&ns_title, &attributes);
+            unsafe {
+                button.set_attributed_title(&attributed);
+            }
+        }
+    }
+
+    fn rebuild_menu(&self, snapshot: &TimerSnapshot, media_state: &SystemMediaState) {
+        unsafe {
+            self.menu.remove_all_items();
+        }
+        match menu_mode(snapshot) {
+            MenuMode::PomodoroRunning => {
+                self.add_section_title("Pomodoro — Work");
+                self.add_pause_reset("pause_pomodoro", "reset_pomodoro");
+                self.add_separator();
+                self.add_item("Start Break", sel!(startBreak:));
+                self.add_separator();
+                self.add_music_menu(snapshot, media_state);
+                self.add_countdown_menu(snapshot);
+                self.add_separator();
+                self.add_item("Open App", sel!(openApp:));
+                self.add_item("Quit", sel!(quitApp:));
+            }
+            MenuMode::BreakRunning => {
+                self.add_section_title("Break Time");
+                self.add_pause_reset("pause_pomodoro", "reset_pomodoro");
+                self.add_separator();
+                self.add_item("Skip Break", sel!(skipBreak:));
+                self.add_separator();
+                self.add_music_menu(snapshot, media_state);
+                self.add_countdown_menu(snapshot);
+                self.add_separator();
+                self.add_item("Open App", sel!(openApp:));
+                self.add_item("Quit", sel!(quitApp:));
+            }
+            MenuMode::CountdownRunning => {
+                self.add_section_title("Countdown Timer");
+                self.add_pause_reset("pause_countdown", "reset_countdown");
+                self.add_separator();
+                self.add_music_menu(snapshot, media_state);
+                self.add_separator();
+                self.add_item("Open Countdown Tab", sel!(openCountdown:));
+                self.add_item("Open App", sel!(openApp:));
+                self.add_item("Quit", sel!(quitApp:));
+            }
+            MenuMode::Idle => {
+                self.add_section_title("Pomodoro Timer");
+                self.add_item("Start Pomodoro", sel!(startPomodoro:));
+                self.add_item("Start Countdown", sel!(startCountdown:));
+                self.add_separator();
+                self.add_music_menu(snapshot, media_state);
+                self.add_separator();
+                self.add_item("Open App", sel!(openApp:));
+                self.add_item("Quit", sel!(quitApp:));
+            }
+        }
+    }
+
+    fn add_section_title(&self, title: &str) {
+        let item = NSMenuItem::alloc().init_with_title_action_key_equivalent(
+            &NSString::from_str(title),
+            None,
+            &NSString::from_str(""),
+        );
+        unsafe {
+            item.set_enabled(false);
+            self.menu.add_item(&item);
+        }
+    }
+
+    fn add_separator(&self) {
+        let item = NSMenuItem::separator_item();
+        unsafe {
+            self.menu.add_item(&item);
+        }
+    }
+
+    fn add_item(&self, title: &str, selector: Sel) {
+        let item = NSMenuItem::alloc().init_with_title_action_key_equivalent(
+            &NSString::from_str(title),
+            Some(selector),
+            &NSString::from_str(""),
+        );
+        unsafe {
+            item.set_target(Some(&self.handler));
+            self.menu.add_item(&item);
+        }
+    }
+
+    fn add_pause_reset(&self, pause_action: &str, reset_action: &str) {
+        self.add_item("⏸ Pause", selector_for_action(pause_action));
+        self.add_item("↺ Reset", selector_for_action(reset_action));
+    }
+
+    fn add_music_menu(&self, snapshot: &TimerSnapshot, media_state: &SystemMediaState) {
+        let menu_item = NSMenuItem::alloc().init_with_title_action_key_equivalent(
+            &NSString::from_str("Music ▶"),
+            None,
+            &NSString::from_str(""),
+        );
+        let submenu = NSMenu::new();
+
+        let play_label = if media_state.is_playing {
+            "⏸ Pause"
+        } else {
+            "▶ Play"
+        };
+        let play_item = NSMenuItem::alloc().init_with_title_action_key_equivalent(
+            &NSString::from_str(play_label),
+            Some(sel!(musicPlayPause:)),
+            &NSString::from_str(""),
+        );
+        unsafe {
+            play_item.set_target(Some(&self.handler));
+            play_item.set_enabled(media_state.available && media_state.supports_play_pause);
+            submenu.add_item(&play_item);
+        }
+
+        let prev_item = NSMenuItem::alloc().init_with_title_action_key_equivalent(
+            &NSString::from_str("⏮ Previous"),
+            Some(sel!(musicPrevious:)),
+            &NSString::from_str(""),
+        );
+        unsafe {
+            prev_item.set_target(Some(&self.handler));
+            prev_item.set_enabled(media_state.supports_previous);
+            submenu.add_item(&prev_item);
+        }
+
+        let next_item = NSMenuItem::alloc().init_with_title_action_key_equivalent(
+            &NSString::from_str("⏭ Next"),
+            Some(sel!(musicNext:)),
+            &NSString::from_str(""),
+        );
+        unsafe {
+            next_item.set_target(Some(&self.handler));
+            next_item.set_enabled(media_state.supports_next);
+            submenu.add_item(&next_item);
+        }
+
+        submenu.add_item(&NSMenuItem::separator_item());
+
+        let focus_parent = NSMenuItem::alloc().init_with_title_action_key_equivalent(
+            &NSString::from_str("Focus Sound ▶"),
+            None,
+            &NSString::from_str(""),
+        );
+        let focus_menu = NSMenu::new();
+        self.add_focus_item(&focus_menu, "Off", FocusSound::Off, snapshot.focus_sound);
+        self.add_focus_item(&focus_menu, "White", FocusSound::White, snapshot.focus_sound);
+        self.add_focus_item(&focus_menu, "Rain", FocusSound::Rain, snapshot.focus_sound);
+        self.add_focus_item(&focus_menu, "Brown", FocusSound::Brown, snapshot.focus_sound);
+        unsafe {
+            focus_parent.set_submenu(Some(&focus_menu));
+            submenu.add_item(&focus_parent);
+        }
+
+        submenu.add_item(&NSMenuItem::separator_item());
+        let open_music = NSMenuItem::alloc().init_with_title_action_key_equivalent(
+            &NSString::from_str("Open Music Tab"),
+            Some(sel!(openMusic:)),
+            &NSString::from_str(""),
+        );
+        unsafe {
+            open_music.set_target(Some(&self.handler));
+            submenu.add_item(&open_music);
+            menu_item.set_submenu(Some(&submenu));
+            self.menu.add_item(&menu_item);
+        }
+    }
+
+    fn add_focus_item(
+        &self,
+        menu: &NSMenu,
+        title: &str,
+        value: FocusSound,
+        current: FocusSound,
+    ) {
+        let item = NSMenuItem::alloc().init_with_title_action_key_equivalent(
+            &NSString::from_str(title),
+            Some(selector_for_focus(value)),
+            &NSString::from_str(""),
+        );
+        unsafe {
+            item.set_target(Some(&self.handler));
+            if value == current {
+                item.set_state(NSControlStateValue::On);
+            }
+            menu.add_item(&item);
+        }
+    }
+
+    fn add_countdown_menu(&self, snapshot: &TimerSnapshot) {
+        let menu_item = NSMenuItem::alloc().init_with_title_action_key_equivalent(
+            &NSString::from_str("Countdown ▶"),
+            None,
+            &NSString::from_str(""),
+        );
+        let submenu = NSMenu::new();
+        let start_item = NSMenuItem::alloc().init_with_title_action_key_equivalent(
+            &NSString::from_str("Start"),
+            Some(sel!(startCountdown:)),
+            &NSString::from_str(""),
+        );
+        let pause_item = NSMenuItem::alloc().init_with_title_action_key_equivalent(
+            &NSString::from_str("Pause"),
+            Some(sel!(pauseCountdown:)),
+            &NSString::from_str(""),
+        );
+        let reset_item = NSMenuItem::alloc().init_with_title_action_key_equivalent(
+            &NSString::from_str("Reset"),
+            Some(sel!(resetCountdown:)),
+            &NSString::from_str(""),
+        );
+        unsafe {
+            start_item.set_target(Some(&self.handler));
+            pause_item.set_target(Some(&self.handler));
+            reset_item.set_target(Some(&self.handler));
+
+            start_item.set_enabled(!snapshot.countdown.running);
+            pause_item.set_enabled(snapshot.countdown.running);
+            reset_item.set_enabled(snapshot.countdown.remaining_seconds
+                < snapshot.countdown.duration_minutes * 60);
+
+            submenu.add_item(&start_item);
+            submenu.add_item(&pause_item);
+            submenu.add_item(&reset_item);
+            submenu.add_item(&NSMenuItem::separator_item());
+            let open_countdown = NSMenuItem::alloc().init_with_title_action_key_equivalent(
+                &NSString::from_str("Open Countdown Tab"),
+                Some(sel!(openCountdown:)),
+                &NSString::from_str(""),
+            );
+            open_countdown.set_target(Some(&self.handler));
+            submenu.add_item(&open_countdown);
+            menu_item.set_submenu(Some(&submenu));
+            self.menu.add_item(&menu_item);
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+unsafe impl Send for StatusBarController {}
+
+#[cfg(target_os = "macos")]
+unsafe impl Sync for StatusBarController {}
+
+#[cfg(target_os = "macos")]
+pub fn init(app: AppHandle, engine: Arc<TimerEngine>) {
+    let controller = StatusBarController::new(app, engine);
+    let _ = STATUS_BAR.set(controller);
+}
+
+#[cfg(target_os = "macos")]
+pub fn update_status_bar(app: &AppHandle, snapshot: &TimerSnapshot) {
+    if STATUS_BAR.get().is_none() {
+        return;
+    }
+    let snapshot = snapshot.clone();
+    let _ = app.run_on_main_thread(move || {
+        if let Some(controller) = STATUS_BAR.get() {
+            controller.update(&snapshot);
+        }
+    });
+}
+
+#[cfg(target_os = "macos")]
+fn build_title(snapshot: &TimerSnapshot) -> String {
+    match menu_mode(snapshot) {
+        MenuMode::PomodoroRunning => format!("🍅 {}", format_mm_ss(snapshot.pomodoro.remaining_seconds)),
+        MenuMode::BreakRunning => format!("☕ {}", format_mm_ss(snapshot.pomodoro.remaining_seconds)),
+        MenuMode::CountdownRunning => format!(
+            "⏱ {}",
+            format_mm_ss(snapshot.countdown.remaining_seconds)
+        ),
+        MenuMode::Idle => "🍅 Ready".to_string(),
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn format_mm_ss(total_seconds: u32) -> String {
+    let minutes = total_seconds / 60;
+    let seconds = total_seconds % 60;
+    format!("{:02}:{:02}", minutes, seconds)
+}
+
+#[cfg(target_os = "macos")]
+fn menu_mode(snapshot: &TimerSnapshot) -> MenuMode {
+    if snapshot.pomodoro.running {
+        match snapshot.pomodoro.mode {
+            PomodoroMode::Work => MenuMode::PomodoroRunning,
+            PomodoroMode::ShortBreak | PomodoroMode::LongBreak => MenuMode::BreakRunning,
+        }
+    } else if snapshot.countdown.running {
+        MenuMode::CountdownRunning
+    } else {
+        MenuMode::Idle
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn selector_for_action(action: &str) -> Sel {
+    match action {
+        "pause_pomodoro" => sel!(pausePomodoro:),
+        "reset_pomodoro" => sel!(resetPomodoro:),
+        "pause_countdown" => sel!(pauseCountdown:),
+        "reset_countdown" => sel!(resetCountdown:),
+        _ => sel!(noop:),
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn selector_for_focus(sound: FocusSound) -> Sel {
+    match sound {
+        FocusSound::Off => sel!(focusOff:),
+        FocusSound::White => sel!(focusWhite:),
+        FocusSound::Rain => sel!(focusRain:),
+        FocusSound::Brown => sel!(focusBrown:),
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn create_handler() -> Id<Object> {
+    static CLASS: OnceCell<&'static Class> = OnceCell::new();
+    let class = CLASS.get_or_init(|| {
+        let superclass = class!(NSObject);
+        let mut decl = ClassDecl::new("PomodoroStatusHandler", superclass)
+            .expect("Unable to register PomodoroStatusHandler class");
+        decl.add_method(sel!(startPomodoro:), start_pomodoro as extern "C" fn(&Object, Sel, *mut Object));
+        decl.add_method(sel!(startBreak:), start_break as extern "C" fn(&Object, Sel, *mut Object));
+        decl.add_method(sel!(skipBreak:), skip_break as extern "C" fn(&Object, Sel, *mut Object));
+        decl.add_method(sel!(pausePomodoro:), pause_pomodoro as extern "C" fn(&Object, Sel, *mut Object));
+        decl.add_method(sel!(resetPomodoro:), reset_pomodoro as extern "C" fn(&Object, Sel, *mut Object));
+        decl.add_method(sel!(startCountdown:), start_countdown as extern "C" fn(&Object, Sel, *mut Object));
+        decl.add_method(sel!(pauseCountdown:), pause_countdown as extern "C" fn(&Object, Sel, *mut Object));
+        decl.add_method(sel!(resetCountdown:), reset_countdown as extern "C" fn(&Object, Sel, *mut Object));
+        decl.add_method(sel!(openApp:), open_app as extern "C" fn(&Object, Sel, *mut Object));
+        decl.add_method(sel!(openMusic:), open_music as extern "C" fn(&Object, Sel, *mut Object));
+        decl.add_method(sel!(openCountdown:), open_countdown as extern "C" fn(&Object, Sel, *mut Object));
+        decl.add_method(sel!(quitApp:), quit_app as extern "C" fn(&Object, Sel, *mut Object));
+        decl.add_method(sel!(musicPlayPause:), music_play_pause as extern "C" fn(&Object, Sel, *mut Object));
+        decl.add_method(sel!(musicPrevious:), music_previous as extern "C" fn(&Object, Sel, *mut Object));
+        decl.add_method(sel!(musicNext:), music_next as extern "C" fn(&Object, Sel, *mut Object));
+        decl.add_method(sel!(focusOff:), focus_off as extern "C" fn(&Object, Sel, *mut Object));
+        decl.add_method(sel!(focusWhite:), focus_white as extern "C" fn(&Object, Sel, *mut Object));
+        decl.add_method(sel!(focusRain:), focus_rain as extern "C" fn(&Object, Sel, *mut Object));
+        decl.add_method(sel!(focusBrown:), focus_brown as extern "C" fn(&Object, Sel, *mut Object));
+        decl.add_method(sel!(noop:), noop as extern "C" fn(&Object, Sel, *mut Object));
+        decl.register()
+    });
+    unsafe { Id::from_retained_ptr(msg_send![class, new]) }
+}
+
+#[cfg(target_os = "macos")]
+extern "C" fn noop(_: &Object, _: Sel, _: *mut Object) {}
+
+#[cfg(target_os = "macos")]
+fn with_engine<F: FnOnce(&Arc<TimerEngine>)>(action: F) {
+    if let Some(engine) = TIMER_ENGINE.get() {
+        action(engine);
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn with_app<F: FnOnce(&AppHandle)>(action: F) {
+    if let Some(app) = APP_HANDLE.get() {
+        action(app);
+    }
+}
+
+#[cfg(target_os = "macos")]
+extern "C" fn start_pomodoro(_: &Object, _: Sel, _: *mut Object) {
+    with_engine(|engine| engine.start_pomodoro());
+}
+
+#[cfg(target_os = "macos")]
+extern "C" fn start_break(_: &Object, _: Sel, _: *mut Object) {
+    with_engine(|engine| engine.start_break());
+}
+
+#[cfg(target_os = "macos")]
+extern "C" fn skip_break(_: &Object, _: Sel, _: *mut Object) {
+    with_engine(|engine| engine.skip_break());
+}
+
+#[cfg(target_os = "macos")]
+extern "C" fn pause_pomodoro(_: &Object, _: Sel, _: *mut Object) {
+    with_engine(|engine| engine.pause_pomodoro());
+}
+
+#[cfg(target_os = "macos")]
+extern "C" fn reset_pomodoro(_: &Object, _: Sel, _: *mut Object) {
+    with_engine(|engine| engine.reset_pomodoro());
+}
+
+#[cfg(target_os = "macos")]
+extern "C" fn start_countdown(_: &Object, _: Sel, _: *mut Object) {
+    with_engine(|engine| engine.start_countdown());
+}
+
+#[cfg(target_os = "macos")]
+extern "C" fn pause_countdown(_: &Object, _: Sel, _: *mut Object) {
+    with_engine(|engine| engine.pause_countdown());
+}
+
+#[cfg(target_os = "macos")]
+extern "C" fn reset_countdown(_: &Object, _: Sel, _: *mut Object) {
+    with_engine(|engine| engine.reset_countdown());
+}
+
+#[cfg(target_os = "macos")]
+extern "C" fn open_app(_: &Object, _: Sel, _: *mut Object) {
+    with_app(|app| {
+        if let Some(window) = app.get_webview_window("main") {
+            let _ = window.show();
+            let _ = window.set_focus();
+        }
+    });
+}
+
+#[cfg(target_os = "macos")]
+extern "C" fn open_music(_: &Object, _: Sel, _: *mut Object) {
+    with_app(|app| {
+        if let Some(window) = app.get_webview_window("main") {
+            let _ = window.show();
+            let _ = window.set_focus();
+        }
+        let _ = app.emit("select-tab", "music");
+    });
+}
+
+#[cfg(target_os = "macos")]
+extern "C" fn open_countdown(_: &Object, _: Sel, _: *mut Object) {
+    with_app(|app| {
+        if let Some(window) = app.get_webview_window("main") {
+            let _ = window.show();
+            let _ = window.set_focus();
+        }
+        let _ = app.emit("select-tab", "countdown");
+    });
+}
+
+#[cfg(target_os = "macos")]
+extern "C" fn quit_app(_: &Object, _: Sel, _: *mut Object) {
+    with_app(|app| app.exit(0));
+}
+
+#[cfg(target_os = "macos")]
+extern "C" fn music_play_pause(_: &Object, _: Sel, _: *mut Object) {
+    let _ = control_media_action("play_pause");
+}
+
+#[cfg(target_os = "macos")]
+extern "C" fn music_previous(_: &Object, _: Sel, _: *mut Object) {
+    let _ = control_media_action("previous");
+}
+
+#[cfg(target_os = "macos")]
+extern "C" fn music_next(_: &Object, _: Sel, _: *mut Object) {
+    let _ = control_media_action("next");
+}
+
+#[cfg(target_os = "macos")]
+extern "C" fn focus_off(_: &Object, _: Sel, _: *mut Object) {
+    handle_focus_sound(FocusSound::Off);
+}
+
+#[cfg(target_os = "macos")]
+extern "C" fn focus_white(_: &Object, _: Sel, _: *mut Object) {
+    handle_focus_sound(FocusSound::White);
+}
+
+#[cfg(target_os = "macos")]
+extern "C" fn focus_rain(_: &Object, _: Sel, _: *mut Object) {
+    handle_focus_sound(FocusSound::Rain);
+}
+
+#[cfg(target_os = "macos")]
+extern "C" fn focus_brown(_: &Object, _: Sel, _: *mut Object) {
+    handle_focus_sound(FocusSound::Brown);
+}
+
+#[cfg(target_os = "macos")]
+fn handle_focus_sound(sound: FocusSound) {
+    with_engine(|engine| engine.set_focus_sound(sound));
+    with_app(|app| {
+        let _ = app.emit("focus_sound", sound);
+    });
+}
+
+#[cfg(target_os = "macos")]

--- a/frontend/src-tauri/src/system_media.rs
+++ b/frontend/src-tauri/src/system_media.rs
@@ -1,0 +1,118 @@
+use serde::Serialize;
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SystemMediaState {
+    pub available: bool,
+    pub title: String,
+    pub artist: Option<String>,
+    pub source: String,
+    pub is_playing: bool,
+    pub supports_play_pause: bool,
+    pub supports_next: bool,
+    pub supports_previous: bool,
+}
+
+#[tauri::command]
+pub fn get_system_media_state() -> SystemMediaState {
+    #[cfg(target_os = "macos")]
+    {
+        if let Some(player) = resolve_media_player() {
+            let (title, artist, is_playing) = query_player_metadata(&player)
+                .unwrap_or_else(|| ("".to_string(), None, false));
+            return SystemMediaState {
+                available: true,
+                title,
+                artist,
+                source: player,
+                is_playing,
+                supports_play_pause: true,
+                supports_next: true,
+                supports_previous: true,
+            };
+        }
+    }
+    SystemMediaState {
+        available: false,
+        title: String::new(),
+        artist: None,
+        source: String::new(),
+        is_playing: false,
+        supports_play_pause: false,
+        supports_next: false,
+        supports_previous: false,
+    }
+}
+
+#[tauri::command]
+pub fn control_system_media(action: String) -> Result<(), String> {
+    #[cfg(target_os = "macos")]
+    {
+        return control_media_action(&action).ok_or_else(|| "Media control unavailable".to_string());
+    }
+    Err("Media control not supported on this platform".to_string())
+}
+
+#[cfg(target_os = "macos")]
+pub fn resolve_media_player() -> Option<String> {
+    if is_process_running("Music") {
+        Some("Music".to_string())
+    } else if is_process_running("Spotify") {
+        Some("Spotify".to_string())
+    } else {
+        None
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn query_player_metadata(player: &str) -> Option<(String, Option<String>, bool)> {
+    let script = format!(
+        "tell application \"{}\" to return (name of current track) & \"||\" & (artist of current track) & \"||\" & (player state as string)",
+        player
+    );
+    let output = run_osascript(&script)?;
+    let parts: Vec<&str> = output.split("||").collect();
+    let title = parts.get(0).unwrap_or(&"").to_string();
+    let artist = parts.get(1).map(|value| value.to_string()).filter(|value| !value.is_empty());
+    let is_playing = parts
+        .get(2)
+        .map(|state| state.trim().eq_ignore_ascii_case("playing"))
+        .unwrap_or(false);
+    Some((title, artist, is_playing))
+}
+
+#[cfg(target_os = "macos")]
+pub fn control_media_action(action: &str) -> Option<()> {
+    let player = resolve_media_player()?;
+    let command = match action {
+        "play_pause" => "playpause",
+        "previous" => "previous track",
+        "next" => "next track",
+        _ => return None,
+    };
+    let script = format!("tell application \"{}\" to {}", player, command);
+    run_osascript(&script).map(|_| ())
+}
+
+#[cfg(target_os = "macos")]
+fn is_process_running(process_name: &str) -> bool {
+    let script = format!(
+        "tell application \"System Events\" to (name of processes) contains \"{}\"",
+        process_name
+    );
+    run_osascript(&script)
+        .map(|output| output.trim().eq_ignore_ascii_case("true"))
+        .unwrap_or(false)
+}
+
+#[cfg(target_os = "macos")]
+fn run_osascript(script: &str) -> Option<String> {
+    let output = std::process::Command::new("osascript")
+        .args(["-e", script])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    Some(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}

--- a/frontend/src-tauri/src/timer.rs
+++ b/frontend/src-tauri/src/timer.rs
@@ -1,0 +1,437 @@
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::Duration;
+
+use serde::Serialize;
+use tauri::{AppHandle, Manager};
+
+use crate::notify_session_complete;
+
+#[derive(Clone, Copy, Debug, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum PomodoroMode {
+    Work,
+    ShortBreak,
+    LongBreak,
+}
+
+#[derive(Clone, Copy, Debug, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum FocusSound {
+    Off,
+    White,
+    Rain,
+    Brown,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PomodoroSettings {
+    pub work_minutes: u32,
+    pub short_break_minutes: u32,
+    pub long_break_minutes: u32,
+    pub sessions_before_long_break: u32,
+    pub auto_long_break: bool,
+    pub pause_music_on_break: bool,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PomodoroSnapshot {
+    pub mode: PomodoroMode,
+    pub running: bool,
+    pub remaining_seconds: u32,
+    pub total_seconds: u32,
+    pub awaiting_next_session: bool,
+    pub auto_start_remaining: u32,
+    pub cycle_work_sessions: u32,
+    pub total_work_sessions: u32,
+    pub total_sessions_completed: u32,
+    pub settings: PomodoroSettings,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CountdownSnapshot {
+    pub duration_minutes: u32,
+    pub remaining_seconds: u32,
+    pub running: bool,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TimerSnapshot {
+    pub pomodoro: PomodoroSnapshot,
+    pub countdown: CountdownSnapshot,
+    pub focus_sound: FocusSound,
+}
+
+#[derive(Clone)]
+pub struct TimerHandle(pub Arc<TimerEngine>);
+
+pub struct TimerEngine {
+    app: AppHandle,
+    state: Mutex<TimerState>,
+}
+
+#[derive(Debug)]
+struct TimerState {
+    pomodoro: PomodoroState,
+    countdown: CountdownState,
+    focus_sound: FocusSound,
+}
+
+#[derive(Debug)]
+struct PomodoroState {
+    mode: PomodoroMode,
+    running: bool,
+    remaining_seconds: u32,
+    total_seconds: u32,
+    awaiting_next_session: bool,
+    auto_start_remaining: u32,
+    cycle_work_sessions: u32,
+    total_work_sessions: u32,
+    total_sessions_completed: u32,
+    settings: PomodoroSettings,
+}
+
+#[derive(Debug)]
+struct CountdownState {
+    duration_minutes: u32,
+    remaining_seconds: u32,
+    running: bool,
+}
+
+const AUTO_START_DELAY_SECONDS: u32 = 5;
+
+impl TimerEngine {
+    pub fn new(app: AppHandle) -> Arc<Self> {
+        let settings = PomodoroSettings {
+            work_minutes: 25,
+            short_break_minutes: 5,
+            long_break_minutes: 15,
+            sessions_before_long_break: 4,
+            auto_long_break: true,
+            pause_music_on_break: false,
+        };
+        let total_seconds = settings.work_minutes * 60;
+        let state = TimerState {
+            pomodoro: PomodoroState {
+                mode: PomodoroMode::Work,
+                running: false,
+                remaining_seconds: total_seconds,
+                total_seconds,
+                awaiting_next_session: false,
+                auto_start_remaining: 0,
+                cycle_work_sessions: 0,
+                total_work_sessions: 0,
+                total_sessions_completed: 0,
+                settings,
+            },
+            countdown: CountdownState {
+                duration_minutes: 25,
+                remaining_seconds: 25 * 60,
+                running: false,
+            },
+            focus_sound: FocusSound::Off,
+        };
+        Arc::new(Self {
+            app,
+            state: Mutex::new(state),
+        })
+    }
+
+    pub fn start(engine: Arc<Self>) {
+        thread::spawn(move || loop {
+            thread::sleep(Duration::from_secs(1));
+            engine.tick();
+        });
+    }
+
+    pub fn snapshot(&self) -> TimerSnapshot {
+        let state = self.state.lock().expect("timer state lock");
+        TimerSnapshot {
+            pomodoro: PomodoroSnapshot {
+                mode: state.pomodoro.mode,
+                running: state.pomodoro.running,
+                remaining_seconds: state.pomodoro.remaining_seconds,
+                total_seconds: state.pomodoro.total_seconds,
+                awaiting_next_session: state.pomodoro.awaiting_next_session,
+                auto_start_remaining: state.pomodoro.auto_start_remaining,
+                cycle_work_sessions: state.pomodoro.cycle_work_sessions,
+                total_work_sessions: state.pomodoro.total_work_sessions,
+                total_sessions_completed: state.pomodoro.total_sessions_completed,
+                settings: state.pomodoro.settings.clone(),
+            },
+            countdown: CountdownSnapshot {
+                duration_minutes: state.countdown.duration_minutes,
+                remaining_seconds: state.countdown.remaining_seconds,
+                running: state.countdown.running,
+            },
+            focus_sound: state.focus_sound,
+        }
+    }
+
+    pub fn emit_snapshot(&self) {
+        let snapshot = self.snapshot();
+        let _ = self.app.emit("timer_state", snapshot);
+        #[cfg(target_os = "macos")]
+        {
+            crate::status_bar::update_status_bar(&self.app, &snapshot);
+        }
+    }
+
+    fn tick(&self) {
+        let mut completed_session: Option<PomodoroMode> = None;
+        {
+            let mut state = self.state.lock().expect("timer state lock");
+            let pomodoro = &mut state.pomodoro;
+            if pomodoro.running {
+                if pomodoro.remaining_seconds > 0 {
+                    pomodoro.remaining_seconds = pomodoro.remaining_seconds.saturating_sub(1);
+                }
+                if pomodoro.remaining_seconds == 0 {
+                    pomodoro.running = false;
+                    pomodoro.awaiting_next_session = true;
+                    pomodoro.auto_start_remaining = AUTO_START_DELAY_SECONDS;
+                    completed_session = Some(pomodoro.mode);
+                    pomodoro.total_sessions_completed += 1;
+                    match pomodoro.mode {
+                        PomodoroMode::Work => {
+                            pomodoro.total_work_sessions += 1;
+                            pomodoro.cycle_work_sessions += 1;
+                            let should_long_break = pomodoro.settings.auto_long_break
+                                && pomodoro.cycle_work_sessions
+                                    >= pomodoro.settings.sessions_before_long_break;
+                            pomodoro.mode = if should_long_break {
+                                PomodoroMode::LongBreak
+                            } else {
+                                PomodoroMode::ShortBreak
+                            };
+                        }
+                        PomodoroMode::ShortBreak => {
+                            pomodoro.mode = PomodoroMode::Work;
+                        }
+                        PomodoroMode::LongBreak => {
+                            pomodoro.mode = PomodoroMode::Work;
+                            pomodoro.cycle_work_sessions = 0;
+                        }
+                    }
+                    pomodoro.total_seconds =
+                        self.duration_for_mode(pomodoro.mode, &pomodoro.settings) * 60;
+                    pomodoro.remaining_seconds = pomodoro.total_seconds;
+                }
+            } else if pomodoro.awaiting_next_session {
+                if pomodoro.auto_start_remaining > 0 {
+                    pomodoro.auto_start_remaining = pomodoro.auto_start_remaining.saturating_sub(1);
+                }
+                if pomodoro.auto_start_remaining == 0 {
+                    pomodoro.awaiting_next_session = false;
+                    pomodoro.running = true;
+                }
+            }
+
+            let countdown = &mut state.countdown;
+            if countdown.running {
+                countdown.remaining_seconds = countdown.remaining_seconds.saturating_sub(1);
+                if countdown.remaining_seconds == 0 {
+                    countdown.running = false;
+                }
+            }
+        }
+
+        if let Some(completed) = completed_session {
+            let mode_label = match completed {
+                PomodoroMode::Work => "work",
+                PomodoroMode::ShortBreak | PomodoroMode::LongBreak => "break",
+            };
+            let _ = notify_session_complete(mode_label.to_string(), self.app.clone());
+        }
+
+        self.emit_snapshot();
+    }
+
+    fn duration_for_mode(&self, mode: PomodoroMode, settings: &PomodoroSettings) -> u32 {
+        match mode {
+            PomodoroMode::Work => settings.work_minutes,
+            PomodoroMode::ShortBreak => settings.short_break_minutes,
+            PomodoroMode::LongBreak => settings.long_break_minutes,
+        }
+    }
+
+    pub fn update_settings(&self, settings: PomodoroSettings) {
+        let mut state = self.state.lock().expect("timer state lock");
+        state.pomodoro.settings = settings.clone();
+        let total_seconds = self.duration_for_mode(state.pomodoro.mode, &settings) * 60;
+        state.pomodoro.total_seconds = total_seconds;
+        if !state.pomodoro.running && !state.pomodoro.awaiting_next_session {
+            state.pomodoro.remaining_seconds = total_seconds;
+        } else if state.pomodoro.remaining_seconds > total_seconds {
+            state.pomodoro.remaining_seconds = total_seconds;
+        }
+        self.emit_snapshot();
+    }
+
+    pub fn start_pomodoro(&self) {
+        let mut state = self.state.lock().expect("timer state lock");
+        let pomodoro = &mut state.pomodoro;
+        pomodoro.mode = PomodoroMode::Work;
+        pomodoro.total_seconds =
+            self.duration_for_mode(pomodoro.mode, &pomodoro.settings) * 60;
+        if pomodoro.remaining_seconds == 0 {
+            pomodoro.remaining_seconds = pomodoro.total_seconds;
+        }
+        pomodoro.awaiting_next_session = false;
+        pomodoro.auto_start_remaining = 0;
+        pomodoro.running = true;
+        self.emit_snapshot();
+    }
+
+    pub fn start_break(&self) {
+        let mut state = self.state.lock().expect("timer state lock");
+        let pomodoro = &mut state.pomodoro;
+        pomodoro.mode = PomodoroMode::ShortBreak;
+        pomodoro.total_seconds =
+            self.duration_for_mode(pomodoro.mode, &pomodoro.settings) * 60;
+        pomodoro.remaining_seconds = pomodoro.total_seconds;
+        pomodoro.awaiting_next_session = false;
+        pomodoro.auto_start_remaining = 0;
+        pomodoro.running = true;
+        self.emit_snapshot();
+    }
+
+    pub fn skip_break(&self) {
+        let mut state = self.state.lock().expect("timer state lock");
+        let pomodoro = &mut state.pomodoro;
+        pomodoro.mode = PomodoroMode::Work;
+        pomodoro.total_seconds =
+            self.duration_for_mode(pomodoro.mode, &pomodoro.settings) * 60;
+        pomodoro.remaining_seconds = pomodoro.total_seconds;
+        pomodoro.awaiting_next_session = false;
+        pomodoro.auto_start_remaining = 0;
+        pomodoro.running = true;
+        self.emit_snapshot();
+    }
+
+    pub fn pause_pomodoro(&self) {
+        let mut state = self.state.lock().expect("timer state lock");
+        state.pomodoro.running = false;
+        state.pomodoro.awaiting_next_session = false;
+        state.pomodoro.auto_start_remaining = 0;
+        self.emit_snapshot();
+    }
+
+    pub fn reset_pomodoro(&self) {
+        let mut state = self.state.lock().expect("timer state lock");
+        let pomodoro = &mut state.pomodoro;
+        pomodoro.running = false;
+        pomodoro.awaiting_next_session = false;
+        pomodoro.auto_start_remaining = 0;
+        pomodoro.total_seconds =
+            self.duration_for_mode(pomodoro.mode, &pomodoro.settings) * 60;
+        pomodoro.remaining_seconds = pomodoro.total_seconds;
+        self.emit_snapshot();
+    }
+
+    pub fn start_countdown(&self) {
+        let mut state = self.state.lock().expect("timer state lock");
+        let countdown = &mut state.countdown;
+        if countdown.remaining_seconds == 0 {
+            countdown.remaining_seconds = countdown.duration_minutes * 60;
+        }
+        countdown.running = true;
+        self.emit_snapshot();
+    }
+
+    pub fn pause_countdown(&self) {
+        let mut state = self.state.lock().expect("timer state lock");
+        state.countdown.running = false;
+        self.emit_snapshot();
+    }
+
+    pub fn reset_countdown(&self) {
+        let mut state = self.state.lock().expect("timer state lock");
+        let countdown = &mut state.countdown;
+        countdown.running = false;
+        countdown.remaining_seconds = countdown.duration_minutes * 60;
+        self.emit_snapshot();
+    }
+
+    pub fn set_countdown_duration(&self, minutes: u32) {
+        let mut state = self.state.lock().expect("timer state lock");
+        let countdown = &mut state.countdown;
+        countdown.duration_minutes = minutes;
+        countdown.remaining_seconds = minutes * 60;
+        countdown.running = false;
+        self.emit_snapshot();
+    }
+
+    pub fn set_focus_sound(&self, sound: FocusSound) {
+        let mut state = self.state.lock().expect("timer state lock");
+        state.focus_sound = sound;
+        self.emit_snapshot();
+    }
+}
+
+#[tauri::command]
+pub fn timer_get_state(state: tauri::State<'_, TimerHandle>) -> TimerSnapshot {
+    state.0.snapshot()
+}
+
+#[tauri::command]
+pub fn pomodoro_update_settings(
+    payload: PomodoroSettings,
+    state: tauri::State<'_, TimerHandle>,
+) {
+    state.0.update_settings(payload);
+}
+
+#[tauri::command]
+pub fn pomodoro_start(state: tauri::State<'_, TimerHandle>) {
+    state.0.start_pomodoro();
+}
+
+#[tauri::command]
+pub fn pomodoro_pause(state: tauri::State<'_, TimerHandle>) {
+    state.0.pause_pomodoro();
+}
+
+#[tauri::command]
+pub fn pomodoro_reset(state: tauri::State<'_, TimerHandle>) {
+    state.0.reset_pomodoro();
+}
+
+#[tauri::command]
+pub fn pomodoro_start_break(state: tauri::State<'_, TimerHandle>) {
+    state.0.start_break();
+}
+
+#[tauri::command]
+pub fn pomodoro_skip_break(state: tauri::State<'_, TimerHandle>) {
+    state.0.skip_break();
+}
+
+#[tauri::command]
+pub fn countdown_start(state: tauri::State<'_, TimerHandle>) {
+    state.0.start_countdown();
+}
+
+#[tauri::command]
+pub fn countdown_pause(state: tauri::State<'_, TimerHandle>) {
+    state.0.pause_countdown();
+}
+
+#[tauri::command]
+pub fn countdown_reset(state: tauri::State<'_, TimerHandle>) {
+    state.0.reset_countdown();
+}
+
+#[tauri::command]
+pub fn countdown_set_duration(minutes: u32, state: tauri::State<'_, TimerHandle>) {
+    state.0.set_countdown_duration(minutes);
+}
+
+#[tauri::command]
+pub fn focus_sound_set(sound: FocusSound, state: tauri::State<'_, TimerHandle>) {
+    state.0.set_focus_sound(sound);
+}

--- a/frontend/src/lib/ipc.ts
+++ b/frontend/src/lib/ipc.ts
@@ -1,4 +1,4 @@
-import { invoke } from '@tauri-apps/api/tauri';
+import { invoke } from '@tauri-apps/api/core';
 
 export type BackendRequest = {
   action: string;

--- a/frontend/src/lib/systemMedia.ts
+++ b/frontend/src/lib/systemMedia.ts
@@ -1,4 +1,4 @@
-import { invoke } from '@tauri-apps/api/tauri';
+import { invoke } from '@tauri-apps/api/core';
 
 export type SystemMediaState = {
   available: boolean;


### PR DESCRIPTION
### Motivation
- Provide a single-source-of-truth timer in the Rust backend that drives Pomodoro, Break and Countdown state and ticks once per second.  
- Replace the previous system-tray approach on macOS with a real NSStatusBar/NSStatusItem that shows a zero‑jitter, monospaced-digit title and a native click menu.  
- Keep all existing UI and JS logic intact while wiring the frontend to the backend commands/events so the menu works even with the main window hidden.  
- Minimize edits and avoid rebuilding the menu every second by only updating the title each tick and rebuilding the menu when logical state changes occur.

### Description
- Added a Rust `TimerEngine` that owns Pomodoro and Countdown state, ticks once per second, emits `timer_state` events and exposes Tauri commands to control timers; file: `frontend/src-tauri/src/timer.rs`.  
- Implemented a macOS-only status bar controller using `objc2` + `objc2-app-kit` that sets an attributed title with `NSFont.monospacedDigitSystemFontOfSize` to avoid jitter and builds an `NSMenu` matching the requested structure; file: `frontend/src-tauri/src/status_bar.rs`.  
- Added best-effort system media support via AppleScript (Spotify/Music) and a small `system_media` bridge that exposes `get_system_media_state` and `control_system_media` commands; file: `frontend/src-tauri/src/system_media.rs`.  
- Wired everything in `main.rs`: upgraded to Tauri 2.x, added `tauri-plugin-notification`, started the `TimerEngine` at setup, registered new commands, and initialized the status bar controller on macOS; file: `frontend/src-tauri/src/main.rs`.  
- Updated frontend to use Tauri 2 APIs and to treat the Rust timer as the single source of truth by invoking backend commands and subscribing to `timer_state` and `focus_sound` events; modified files: `frontend/src/App.svelte`, `frontend/src/lib/countdownStore.ts`, `frontend/src/lib/ipc.ts`, `frontend/src/lib/systemMedia.ts`, and package/Cargo upgrades in `frontend/package.json` and `frontend/src-tauri/Cargo.toml`.

### Testing
- No automated tests were added or executed as part of this change.  
- The new commands and event emission were wired so the frontend calls `timer_get_state` on mount and listens for `timer_state` updates (manual runtime observation expected).  
- The macOS status bar code is guarded by `#[cfg(target_os = "macos")]` to avoid affecting other platforms.  
- Manual runtime validation is recommended on macOS to confirm menu actions work with the app window hidden and the title updates every second without layout jitter.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963bdad9c408323b35828d744c6dcd4)