### PR TITLE
Remove Tauri `shell` allowlist to avoid unsupported `shell-all` feature

### DIFF
--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -10,11 +10,6 @@
     "version": "0.1.0"
   },
   "tauri": {
-    "allowlist": {
-      "shell": {
-        "all": true
-      }
-    },
     "bundle": {
       "active": true,
       "targets": "all",


### PR DESCRIPTION
### Motivation
- A build error indicated the project depends on `tauri` without the `shell-all` feature while the config enabled full shell allowlist access (`shell-all`).
- The intent is to avoid requesting an unsupported `tauri` feature (`shell-all`) for the locked `tauri` 2.9.x version.
- The change keeps the app configuration consistent with the installed `tauri` features to prevent dependency resolution failures.
- Unintended local dependency lockfile and build artifacts were observed and not intended to be part of this change.

### Description
- Removed the `"allowlist": { "shell": { "all": true } }` block from `frontend/src-tauri/tauri.conf.json` so the `shell` allowlist is no longer enabled.
- Left the `tauri.bundle`, `systemTray`, and `windows` configuration intact in `frontend/src-tauri/tauri.conf.json`.
- Reverted accidental changes to `Cargo.lock` and build artifact files so only the config change remains.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963c6c4b0208323a7efa7c3ff2d59f2)