### PR TITLE
Remove Tauri `systemTray` and `allowlist.shell` config for 2.9 compatibility

### DIFF
--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -10,18 +10,10 @@
     "version": "0.1.0"
   },
   "tauri": {
-    "allowlist": {
-      "shell": {
-        "all": true
-      }
-    },
     "bundle": {
       "active": true,
       "targets": "all",
       "identifier": "com.pomodoro.app"
-    },
-    "systemTray": {
-      "iconPath": "icons/icon.png"
     },
     "windows": [
       {


### PR DESCRIPTION
### Motivation
- A build error showed the project depended on `tauri` locked to 2.9.x while the config implied unsupported features, causing dependency resolution failures.
- The `tauri.conf.json` previously enabled `shell.all` and `systemTray`, which correspond to `shell-all` and `system-tray` features not available for the locked `tauri` version.
- The change aligns runtime configuration with the installed `tauri` feature set to prevent build-time feature conflicts.
- Keep the app configuration minimal to avoid requesting unsupported features during CI or local builds.

### Description
- Removed the `"allowlist": { "shell": { "all": true } }` block from `frontend/src-tauri/tauri.conf.json`.
- Removed the `"systemTray": { "iconPath": "icons/icon.png" }` block from `frontend/src-tauri/tauri.conf.json`.
- Preserved the existing `bundle`, `windows`, and other `tauri` settings in `frontend/src-tauri/tauri.conf.json`.
- The updated file was staged and committed.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963c6c4b0208323a7efa7c3ff2d59f2)