### PR TITLE
Define status-bar feature and fix Arc ownership

### DIFF
--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -20,3 +20,4 @@ objc2-app-kit = "0.2"
 
 [features]
 custom-protocol = ["tauri/custom-protocol"]
+status-bar = []

--- a/frontend/src-tauri/src/main.rs
+++ b/frontend/src-tauri/src/main.rs
@@ -4,6 +4,8 @@ mod status_bar;
 mod system_media;
 mod timer;
 
+use std::sync::Arc;
+
 use tauri::{AppHandle, Manager, WindowEvent};
 use tauri_plugin_notification::NotificationExt;
 
@@ -45,9 +47,9 @@ fn main() {
             let engine = TimerEngine::new(app.handle().clone());
             TimerEngine::start(engine.clone());
             app.manage(TimerHandle(engine.clone()));
-            #[cfg(target_os = "macos")]
+            #[cfg(all(target_os = "macos", feature = "status-bar"))]
             {
-                status_bar::init(app.handle().clone(), engine);
+                status_bar::init(app.handle().clone(), Arc::clone(&engine));
             }
             engine.emit_snapshot();
             Ok(())

--- a/frontend/src-tauri/src/timer.rs
+++ b/frontend/src-tauri/src/timer.rs
@@ -175,7 +175,7 @@ impl TimerEngine {
     pub fn emit_snapshot(&self) {
         let snapshot = self.snapshot();
         let _ = self.app.emit("timer_state", &snapshot);
-        #[cfg(target_os = "macos")]
+        #[cfg(all(target_os = "macos", feature = "status-bar"))]
         {
             crate::status_bar::update_status_bar(&self.app, &snapshot);
         }


### PR DESCRIPTION
### Motivation
- Silence the `unexpected cfg condition value: status-bar` warning by properly declaring the feature in `Cargo.toml`.
- Ensure macOS-only status bar logic remains gated behind a compile-time feature to avoid surprising platform builds.
- Fix the ownership error where `engine` was moved into `status_bar::init`, keeping the timer engine usable afterward.

### Description
- Added `status-bar = []` to the `[features]` section of `frontend/src-tauri/Cargo.toml` to declare the feature explicitly.
- Replaced `#[cfg(target_os = "macos")]` with `#[cfg(all(target_os = "macos", feature = "status-bar"))]` in `frontend/src-tauri/src/main.rs` and `frontend/src-tauri/src/timer.rs` to gate status-bar code behind the new feature.
- Preserved shared ownership of the engine by adding `use std::sync::Arc;` and calling `status_bar::init(app.handle().clone(), Arc::clone(&engine));` so the `Arc<TimerEngine>` is cloned rather than moved.
- These changes declare the feature to satisfy the compiler and use `Arc::clone` to maintain shared ownership so `engine` is still usable after initialization.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696655203d9483239485cd6180dd5bae)