### PR TITLE
Ensure Tauri builds frontend assets before packaging

### DIFF
--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -4,10 +4,11 @@
   "identifier": "com.pomodoro.app",
 
   "build": {
-  "devUrl": "http://localhost:5173",
-  "frontendDist": "../dist",
-  "beforeDevCommand": "npm run dev"
-},
+    "devUrl": "http://localhost:5173",
+    "frontendDist": "../dist",
+    "beforeDevCommand": "npm run dev",
+    "beforeBuildCommand": "npm run build"
+  },
 
   "app": {
     "windows": [


### PR DESCRIPTION
### Motivation
- The packaged app showed a blank white window because the native Tauri bundle referenced `frontendDist` but the frontend build output in `../dist` was not being produced before packaging. 
- Tauri's production packaging step was not running the frontend build, so the webview had no HTML/JS to load at runtime. 
- Adding an explicit pre-build step guarantees the compiled frontend assets exist when the native app starts. 
- The fix targets the build lifecycle rather than changing runtime or framework code.

### Description
- Added `"beforeBuildCommand": "npm run build"` to `frontend/src-tauri/tauri.conf.json` so Tauri runs the frontend build during packaging. 
- Kept existing `devUrl` and `frontendDist` settings unchanged and only injected the missing build step. 
- Ensures the `../dist` directory is populated before creating the native bundle so the webview can load the UI. 
- No frontend source files or runtime code were modified.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696657f2896c8323ab14ea42ea9f51e2)