### PR TITLE
Fix Tauri dev/build command paths for frontend

### DIFF
--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -6,8 +6,8 @@
   "build": {
     "devUrl": "http://localhost:5173",
     "frontendDist": "../dist",
-    "beforeDevCommand": "npm run dev",
-    "beforeBuildCommand": "npm run build"
+    "beforeDevCommand": "npm --prefix .. run dev",
+    "beforeBuildCommand": "npm --prefix .. run build"
   },
 
   "app": {


### PR DESCRIPTION
### Motivation
- The Tauri build hooks were calling `npm run dev` / `npm run build` without targeting the frontend package, so the frontend dev server or build output was not produced and the webview had nothing to load.
- The Tauri context is inside `frontend/src-tauri`, while the npm scripts are defined in the `frontend` directory, creating a working-directory mismatch.
- This caused the app window to open but render a blank white content area because no served or built assets were available to the webview.

### Description
- Updated `frontend/src-tauri/tauri.conf.json` to use `beforeDevCommand: "npm --prefix .. run dev"` to run the frontend dev server from the correct location.
- Updated `frontend/src-tauri/tauri.conf.json` to use `beforeBuildCommand: "npm --prefix .. run build"` to build the frontend from the correct location.
- These changes ensure the `frontend/package.json` scripts are executed from the frontend root so the web assets are served/built for Tauri to load.

### Testing
- No automated tests were run because this is a configuration-only change.
- (No test failures were reported.)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69665a7ec81c83239f0aecd8b22aaaa5)