### PR TITLE
Guard Tauri IPC usage during frontend startup

### DIFF
--- a/frontend/src/lib/countdownStore.ts
+++ b/frontend/src/lib/countdownStore.ts
@@ -1,5 +1,5 @@
 import { writable } from 'svelte/store';
-import { invoke } from '@tauri-apps/api/core';
+import { safeInvoke } from './tauri';
 
 const STORAGE_KEY = 'countdown_duration_minutes';
 const MINUTES_MIN = 1;
@@ -37,15 +37,15 @@ const createCountdownStore = () => {
   };
 
   const startCountdown = async () => {
-    await invoke('countdown_start');
+    await safeInvoke('countdown_start');
   };
 
   const pauseCountdown = async () => {
-    await invoke('countdown_pause');
+    await safeInvoke('countdown_pause');
   };
 
   const resetCountdown = async () => {
-    await invoke('countdown_reset');
+    await safeInvoke('countdown_reset');
   };
 
   const setDurationMinutes = (value: number) => {
@@ -53,7 +53,7 @@ const createCountdownStore = () => {
     remainingSeconds = durationMinutes * 60;
     running = false;
     localStorage.setItem(STORAGE_KEY, String(durationMinutes));
-    void invoke('countdown_set_duration', { minutes: durationMinutes });
+    void safeInvoke('countdown_set_duration', { minutes: durationMinutes });
     publish();
   };
 
@@ -74,7 +74,7 @@ const createCountdownStore = () => {
       durationMinutes = clampMinutes(defaultMinutes, defaultMinutes);
       remainingSeconds = durationMinutes * 60;
     }
-    void invoke('countdown_set_duration', { minutes: durationMinutes });
+    void safeInvoke('countdown_set_duration', { minutes: durationMinutes });
     publish();
   };
 

--- a/frontend/src/lib/ipc.ts
+++ b/frontend/src/lib/ipc.ts
@@ -1,4 +1,4 @@
-import { invoke } from '@tauri-apps/api/core';
+import { safeInvoke } from './tauri';
 
 export type BackendRequest = {
   action: string;
@@ -12,7 +12,8 @@ export type BackendResponse = {
 };
 
 export async function send(request: BackendRequest): Promise<BackendResponse> {
-  return invoke('backend_request', { payload: request });
+  const response = await safeInvoke<BackendResponse>('backend_request', { payload: request });
+  return response ?? { ok: false, error: 'Backend unavailable' };
 }
 
 export async function getState(): Promise<BackendResponse> {

--- a/frontend/src/lib/systemMedia.ts
+++ b/frontend/src/lib/systemMedia.ts
@@ -1,4 +1,4 @@
-import { invoke } from '@tauri-apps/api/core';
+import { safeInvoke } from './tauri';
 
 export type SystemMediaState = {
   available: boolean;
@@ -12,9 +12,13 @@ export type SystemMediaState = {
 };
 
 export async function getSystemMediaState(): Promise<SystemMediaState> {
-  return invoke('get_system_media_state');
+  const state = await safeInvoke<SystemMediaState>('get_system_media_state');
+  if (!state) {
+    throw new Error('System media state unavailable');
+  }
+  return state;
 }
 
 export async function controlSystemMedia(action: 'play_pause' | 'next' | 'previous') {
-  return invoke('control_system_media', { action });
+  return safeInvoke('control_system_media', { action });
 }

--- a/frontend/src/lib/tauri.ts
+++ b/frontend/src/lib/tauri.ts
@@ -1,0 +1,31 @@
+import { invoke } from '@tauri-apps/api/core';
+import { listen } from '@tauri-apps/api/event';
+
+const getTauriInternals = () =>
+  typeof window !== 'undefined'
+    ? (window as Window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__
+    : undefined;
+
+const isTauriAvailable = () => getTauriInternals() !== undefined;
+
+export const safeInvoke = async <T>(
+  command: string,
+  args?: Record<string, unknown>
+): Promise<T | undefined> => {
+  if (!isTauriAvailable()) {
+    return undefined;
+  }
+
+  return invoke<T>(command, args);
+};
+
+export const safeListen = async <T>(
+  event: string,
+  handler: Parameters<typeof listen<T>>[1]
+): Promise<() => void> => {
+  if (!isTauriAvailable()) {
+    return () => undefined;
+  }
+
+  return listen<T>(event, handler);
+};


### PR DESCRIPTION
### Motivation
- The frontend invoked Tauri IPC and registered event listeners during app mount before Tauri internals were available, which produced runtime errors like "Cannot read properties of undefined (reading 'invoke')" and caused a white screen.

### Description
- Add `frontend/src/lib/tauri.ts` with `safeInvoke` and `safeListen` helpers that check `window.__TAURI_INTERNALS__` before calling `invoke`/`listen`.
- Replace direct `invoke`/`listen` usages in `App.svelte`, `countdownStore.ts`, `systemMedia.ts`, and `ipc.ts` to use `safeInvoke`/`safeListen` and avoid calling backend APIs when Tauri is not present.
- Add small defensive checks for missing backend responses (skip applying an undefined `timer_get_state` snapshot and return a fallback response from `send`).
- Confine changes to the frontend only and avoid refactoring logic, UI structure, or backend code.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696770a5072c8323a11654572410f5b3)