### PR TITLE
Add startup guards and defensive invokes to frontend to prevent white screen

### DIFF
--- a/frontend/src/App.module.css
+++ b/frontend/src/App.module.css
@@ -108,6 +108,19 @@
   color: var(--app-text);
 }
 
+.startupBanner {
+  position: absolute;
+  top: 18px;
+  left: 24px;
+  padding: 6px 12px;
+  border-radius: 999px;
+  background: rgba(20, 28, 44, 0.1);
+  color: var(--app-text);
+  font-size: 12px;
+  letter-spacing: 0.02em;
+  z-index: 3;
+}
+
 .glassBackground {
   position: fixed;
   inset: 0;

--- a/frontend/src/lib/countdownStore.ts
+++ b/frontend/src/lib/countdownStore.ts
@@ -37,15 +37,21 @@ const createCountdownStore = () => {
   };
 
   const startCountdown = async () => {
-    await safeInvoke('countdown_start');
+    await safeInvoke('countdown_start').catch((error) => {
+      console.error('Failed to start countdown', error);
+    });
   };
 
   const pauseCountdown = async () => {
-    await safeInvoke('countdown_pause');
+    await safeInvoke('countdown_pause').catch((error) => {
+      console.error('Failed to pause countdown', error);
+    });
   };
 
   const resetCountdown = async () => {
-    await safeInvoke('countdown_reset');
+    await safeInvoke('countdown_reset').catch((error) => {
+      console.error('Failed to reset countdown', error);
+    });
   };
 
   const setDurationMinutes = (value: number) => {
@@ -53,7 +59,9 @@ const createCountdownStore = () => {
     remainingSeconds = durationMinutes * 60;
     running = false;
     localStorage.setItem(STORAGE_KEY, String(durationMinutes));
-    void safeInvoke('countdown_set_duration', { minutes: durationMinutes });
+    void safeInvoke('countdown_set_duration', { minutes: durationMinutes }).catch((error) => {
+      console.error('Failed to update countdown duration', error);
+    });
     publish();
   };
 
@@ -74,7 +82,9 @@ const createCountdownStore = () => {
       durationMinutes = clampMinutes(defaultMinutes, defaultMinutes);
       remainingSeconds = durationMinutes * 60;
     }
-    void safeInvoke('countdown_set_duration', { minutes: durationMinutes });
+    void safeInvoke('countdown_set_duration', { minutes: durationMinutes }).catch((error) => {
+      console.error('Failed to initialize countdown duration', error);
+    });
     publish();
   };
 


### PR DESCRIPTION
### Motivation
- Prevent frontend startup from being blocked by unhandled backend rejections so the window always renders a visible UI and the first crash can be isolated.
- Provide minimal diagnostics and safe toggles to enable backend calls one-by-one during debugging without changing app behavior or business logic.

### Description
- Add top-level startup guard and sequential startup steps via `runStartupStep` and `startupBackendToggles` to control and isolate backend features (`invoke`, `listen`, `countdown`, `systemMedia`) in `frontend/src/App.svelte`.
- Render an unconditional fallback banner `App Loaded` and log `App mounted` to the console so the UI is visible during early boot in `frontend/src/App.svelte` and styled in `frontend/src/App.module.css`.
- Add `.catch(...)` handlers around `safeInvoke` calls used during startup and user actions (notably `pomodoro_update_settings`, timer control invokes, and focus sound updates) to prevent unhandled promise rejections; the key guarded location is `updateSettings()` in `frontend/src/App.svelte` (around the `pomodoro_update_settings` call, ~L520-L546).
- Add defensive error handling to countdown-related backend calls in `frontend/src/lib/countdownStore.ts` to avoid startup crashes when countdown-related invokes fail.

### Testing
- Started the dev server with `npm run dev` and confirmed Vite was ready (local server at `http://localhost:4173/`), which succeeded.
- Loaded the app with a headless browser using Playwright and captured a screenshot showing the visible `App Loaded` banner, confirming the UI renders even when backend is unavailable, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967923ce5688323a6d3914dbfbc095b)