### PR TITLE
Fix macOS status bar gating

### DIFF
--- a/frontend/src-tauri/src/status_bar.rs
+++ b/frontend/src-tauri/src/status_bar.rs
@@ -1,4 +1,4 @@
-#[cfg(all(target_os = "macos", feature = "status-bar"))]
+#[cfg(target_os = "macos")]
 mod macos {
 #[cfg(target_os = "macos")]
 use std::sync::{Arc, Mutex};
@@ -618,18 +618,18 @@ fn handle_focus_sound(sound: FocusSound) {
 }
 }
 
-#[cfg(all(target_os = "macos", feature = "status-bar"))]
+#[cfg(target_os = "macos")]
 pub use macos::{init, update_status_bar};
 
-#[cfg(not(all(target_os = "macos", feature = "status-bar")))]
+#[cfg(not(target_os = "macos"))]
 use std::sync::Arc;
-#[cfg(not(all(target_os = "macos", feature = "status-bar")))]
+#[cfg(not(target_os = "macos"))]
 use tauri::AppHandle;
-#[cfg(not(all(target_os = "macos", feature = "status-bar")))]
+#[cfg(not(target_os = "macos"))]
 use crate::timer::{TimerEngine, TimerSnapshot};
 
-#[cfg(not(all(target_os = "macos", feature = "status-bar")))]
+#[cfg(not(target_os = "macos"))]
 pub fn init(_app: AppHandle, _engine: Arc<TimerEngine>) {}
 
-#[cfg(not(all(target_os = "macos", feature = "status-bar")))]
+#[cfg(not(target_os = "macos"))]
 pub fn update_status_bar(_app: &AppHandle, _snapshot: &TimerSnapshot) {}


### PR DESCRIPTION
### Motivation

- The macOS status bar, timer engine initialization, and related app logic were compiled out because code was gated behind `#[cfg(all(target_os = "macos", feature = "status-bar"))]`, but the Cargo feature `status-bar` was not defined or enabled. 
- The intent of the change is to ensure the real macOS `StatusBarController` and the functions `init` and `update_status_bar` are compiled and run on macOS without requiring any Cargo feature.

### Description

- Replaced all occurrences of `#[cfg(all(target_os = "macos", feature = "status-bar"))]` with `#[cfg(target_os = "macos")]` so the macOS implementation (`mod macos`) and exports are compiled on macOS. 
- Re-scoped the no-op stubs to `#[cfg(not(target_os = "macos"))]` so non-macOS builds keep trivial `init`/`update_status_bar` stubs while macOS uses the real implementation. 
- Ensures `init(app, engine)` and `update_status_bar` are not compiled out on macOS and that the status bar controller logic runs at runtime.

### Testing

- No automated tests were run on the modified code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69679ad57a908323bb3ab15b92841e7d)