### PR TITLE
Fix macOS status bar font handling

### DIFF
--- a/frontend/src-tauri/src/status_bar.rs
+++ b/frontend/src-tauri/src/status_bar.rs
@@ -14,7 +14,7 @@ use objc2::{class, msg_send, sel};
 #[cfg(target_os = "macos")]
 use objc2_app_kit::{
     NSAttributedString, NSControlStateValue, NSFont, NSMenu, NSMenuItem, NSStatusBar,
-    NSStatusItem, NSStatusItemLength,
+    NSStatusBarButton, NSStatusItem, NSStatusItemLength,
 };
 #[cfg(target_os = "macos")]
 use objc2_foundation::{NSDictionary, NSString};
@@ -116,9 +116,14 @@ impl StatusBarController {
 
     fn set_title(&self, title: &str) {
         if let Some(button) = unsafe { self.status_item.button() } {
+            let button: Id<NSStatusBarButton> = button;
             let font: Id<NSFont> = unsafe {
-                let font: *mut NSFont = msg_send![class!(NSFont), monospacedDigitSystemFontOfSize: 0.0 weight: 0.0];
-                Id::retain_autoreleased(font).expect("NSFont retained")
+                let font: *mut NSFont = msg_send![
+                    class!(NSFont),
+                    monospacedDigitSystemFontOfSize: 0.0
+                    weight: 0.0
+                ];
+                Id::retain(font).expect("NSFont retained")
             };
             let ns_title = NSString::from_str(title);
             let attributes = NSDictionary::from_keys_and_objects(


### PR DESCRIPTION
### Motivation
- Update the macOS status bar title code to use the current `objc2` APIs and explicit types to address compile errors around retained pointers and message sending when building attributed titles.

### Description
- Import `NSStatusBarButton`, cast the status item button to `Id<NSStatusBarButton>`, and switch to `Id::retain` with an updated `msg_send!` call for `monospacedDigitSystemFontOfSize:weight:` to properly retain the `NSFont` used in attributed titles in `frontend/src-tauri/src/status_bar.rs`.

### Testing
- No automated tests were run on this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69679f09e564832381a62237cc78aa4f)