### PR TITLE
Add SwiftUI macOS app foundation with menu bar controller

### DIFF
--- a/macos/PomodoroApp/AppState.swift
+++ b/macos/PomodoroApp/AppState.swift
@@ -1,0 +1,25 @@
+import AppKit
+import SwiftUI
+
+final class AppState: ObservableObject {
+    private let menuBarController: MenuBarController
+
+    init() {
+        menuBarController = MenuBarController(
+            openMainWindow: { [weak self] in
+                self?.focusMainWindow()
+            },
+            quit: {
+                NSApplication.shared.terminate(nil)
+            }
+        )
+    }
+
+    func focusMainWindow() {
+        NSApplication.shared.activate(ignoringOtherApps: true)
+
+        if let window = NSApplication.shared.windows.first {
+            window.makeKeyAndOrderFront(nil)
+        }
+    }
+}

--- a/macos/PomodoroApp/MainWindowView.swift
+++ b/macos/PomodoroApp/MainWindowView.swift
@@ -1,0 +1,18 @@
+import SwiftUI
+
+struct MainWindowView: View {
+    var body: some View {
+        VStack(spacing: 12) {
+            Text("Pomodoro")
+                .font(.largeTitle)
+            Text("Ready to focus.")
+                .foregroundStyle(.secondary)
+        }
+        .frame(minWidth: 480, minHeight: 320)
+        .padding(32)
+    }
+}
+
+#Preview {
+    MainWindowView()
+}

--- a/macos/PomodoroApp/MenuBarController.swift
+++ b/macos/PomodoroApp/MenuBarController.swift
@@ -1,0 +1,48 @@
+import AppKit
+
+final class MenuBarController {
+    private let statusItem: NSStatusItem
+    private let openMainWindow: () -> Void
+    private let quit: () -> Void
+
+    init(openMainWindow: @escaping () -> Void, quit: @escaping () -> Void) {
+        self.openMainWindow = openMainWindow
+        self.quit = quit
+        statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
+        configureStatusItem()
+    }
+
+    private func configureStatusItem() {
+        if let button = statusItem.button {
+            button.title = "Pomodoro"
+        }
+
+        let menu = NSMenu()
+        let openItem = NSMenuItem(
+            title: "Open Pomodoro",
+            action: #selector(openMainWindowAction),
+            keyEquivalent: "o"
+        )
+        openItem.target = self
+        menu.addItem(openItem)
+        menu.addItem(.separator())
+
+        let quitItem = NSMenuItem(
+            title: "Quit",
+            action: #selector(quitAction),
+            keyEquivalent: "q"
+        )
+        quitItem.target = self
+        menu.addItem(quitItem)
+
+        statusItem.menu = menu
+    }
+
+    @objc private func openMainWindowAction() {
+        openMainWindow()
+    }
+
+    @objc private func quitAction() {
+        quit()
+    }
+}

--- a/macos/PomodoroApp/PomodoroApp.swift
+++ b/macos/PomodoroApp/PomodoroApp.swift
@@ -1,0 +1,13 @@
+import SwiftUI
+
+@main
+struct PomodoroApp: App {
+    @StateObject private var appState = AppState()
+
+    var body: some Scene {
+        WindowGroup {
+            MainWindowView()
+                .environmentObject(appState)
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a minimal, idiomatic SwiftUI macOS foundation that launches, shows a main window, and exposes a native menu bar status item with open/focus and quit actions to satisfy Day 1 objectives.
- Keep a clear separation of responsibilities so app entry, global state, menu bar handling, and main window UI are easy to extend later.

### Description
- Add `PomodoroApp.swift` as the SwiftUI `@main` entry that injects a single `@StateObject` `AppState` into the window scene.
- Add `AppState.swift` which owns app-level behavior, initializes the `MenuBarController`, and provides `focusMainWindow()` to activate and bring the main window forward.
- Add `MenuBarController.swift` which encapsulates a native `NSStatusItem` and builds an `NSMenu` containing `Open Pomodoro`, a separator, and `Quit`, wiring menu actions to provided closures.
- Add `MainWindowView.swift` as a small, focused SwiftUI view (with preview) that defines the initial window UI and sizing constraints.

### Testing
- No automated tests were executed for this change (none were requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968e22839408323bcb2d15b4d344f12)