### PR TITLE
Add single-source-of-truth AppState and timer engines (Pomodoro + Countdown)

### DIFF
--- a/macos/Pomodoro/Pomodoro/AppState.swift
+++ b/macos/Pomodoro/Pomodoro/AppState.swift
@@ -1,0 +1,36 @@
+//
+//  AppState.swift
+//  Pomodoro
+//
+//  Created by Zhengyang Hu on 1/15/26.
+//
+
+import Combine
+import SwiftUI
+
+final class AppState: ObservableObject {
+    let pomodoro: PomodoroTimerEngine
+    let countdown: CountdownTimerEngine
+
+    private var cancellables: Set<AnyCancellable> = []
+
+    init(
+        pomodoro: PomodoroTimerEngine = PomodoroTimerEngine(),
+        countdown: CountdownTimerEngine = CountdownTimerEngine()
+    ) {
+        self.pomodoro = pomodoro
+        self.countdown = countdown
+
+        pomodoro.objectWillChange
+            .sink { [weak self] _ in
+                self?.objectWillChange.send()
+            }
+            .store(in: &cancellables)
+
+        countdown.objectWillChange
+            .sink { [weak self] _ in
+                self?.objectWillChange.send()
+            }
+            .store(in: &cancellables)
+    }
+}

--- a/macos/Pomodoro/Pomodoro/ContentView.swift
+++ b/macos/Pomodoro/Pomodoro/ContentView.swift
@@ -9,16 +9,11 @@ import SwiftUI
 
 struct ContentView: View {
     var body: some View {
-        VStack {
-            Image(systemName: "globe")
-                .imageScale(.large)
-                .foregroundStyle(.tint)
-            Text("Hello, world!")
-        }
-        .padding()
+        MainWindowView()
     }
 }
 
 #Preview {
     ContentView()
+        .environmentObject(AppState())
 }

--- a/macos/Pomodoro/Pomodoro/CountdownTimerEngine.swift
+++ b/macos/Pomodoro/Pomodoro/CountdownTimerEngine.swift
@@ -1,0 +1,86 @@
+//
+//  CountdownTimerEngine.swift
+//  Pomodoro
+//
+//  Created by Zhengyang Hu on 1/15/26.
+//
+
+import Foundation
+
+final class CountdownTimerEngine: ObservableObject {
+    enum State: String {
+        case idle
+        case running
+        case paused
+
+        var isRunning: Bool { self == .running }
+        var isPaused: Bool { self == .paused }
+    }
+
+    @Published private(set) var state: State = .idle
+    @Published private(set) var remainingSeconds: Int
+
+    private let duration: Int
+    private var timer: Timer?
+
+    init(duration: Int = 10 * 60) {
+        self.duration = duration
+        self.remainingSeconds = duration
+    }
+
+    func start() {
+        guard state == .idle else { return }
+        remainingSeconds = duration
+        state = .running
+        startTimer()
+    }
+
+    func pause() {
+        guard state == .running else { return }
+        state = .paused
+        stopTimer()
+    }
+
+    func resume() {
+        guard state == .paused else { return }
+        state = .running
+        startTimer()
+    }
+
+    func reset() {
+        stopTimer()
+        state = .idle
+        remainingSeconds = duration
+    }
+
+    private func startTimer() {
+        stopTimer()
+        timer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
+            self?.tick()
+        }
+    }
+
+    private func stopTimer() {
+        timer?.invalidate()
+        timer = nil
+    }
+
+    private func tick() {
+        guard remainingSeconds > 0 else {
+            complete()
+            return
+        }
+
+        remainingSeconds -= 1
+
+        if remainingSeconds == 0 {
+            complete()
+        }
+    }
+
+    private func complete() {
+        stopTimer()
+        state = .idle
+        remainingSeconds = duration
+    }
+}

--- a/macos/Pomodoro/Pomodoro/MainWindowView.swift
+++ b/macos/Pomodoro/Pomodoro/MainWindowView.swift
@@ -1,0 +1,98 @@
+//
+//  MainWindowView.swift
+//  Pomodoro
+//
+//  Created by Zhengyang Hu on 1/15/26.
+//
+
+import SwiftUI
+
+struct MainWindowView: View {
+    @EnvironmentObject private var appState: AppState
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            VStack(alignment: .leading, spacing: 8) {
+                Text(appState.pomodoro.state.isOnBreak ? "Break" : "Pomodoro")
+                    .font(.headline)
+                Text(formattedTime(appState.pomodoro.remainingSeconds))
+                    .font(.title)
+                Text("State: \(labelForPomodoroState(appState.pomodoro.state))")
+                    .font(.subheadline)
+            }
+
+            HStack(spacing: 12) {
+                Button("Start") {
+                    appState.pomodoro.start()
+                }
+                Button("Pause") {
+                    appState.pomodoro.pause()
+                }
+                Button("Resume") {
+                    appState.pomodoro.resume()
+                }
+                Button("Reset") {
+                    appState.pomodoro.reset()
+                }
+                Button("Skip Break") {
+                    appState.pomodoro.skipBreak()
+                }
+            }
+
+            Divider()
+
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Countdown")
+                    .font(.headline)
+                Text(formattedTime(appState.countdown.remainingSeconds))
+                    .font(.title)
+                Text("State: \(appState.countdown.state.rawValue.capitalized)")
+                    .font(.subheadline)
+            }
+
+            HStack(spacing: 12) {
+                Button("Start") {
+                    appState.countdown.start()
+                }
+                Button("Pause") {
+                    appState.countdown.pause()
+                }
+                Button("Resume") {
+                    appState.countdown.resume()
+                }
+                Button("Reset") {
+                    appState.countdown.reset()
+                }
+            }
+        }
+        .padding()
+        .frame(minWidth: 360)
+    }
+
+    private func formattedTime(_ seconds: Int) -> String {
+        let clampedSeconds = max(0, seconds)
+        let minutes = clampedSeconds / 60
+        let remaining = clampedSeconds % 60
+        return String(format: "%02d:%02d", minutes, remaining)
+    }
+
+    private func labelForPomodoroState(_ state: PomodoroTimerEngine.State) -> String {
+        switch state {
+        case .idle:
+            return "Idle"
+        case .running:
+            return "Running"
+        case .paused:
+            return "Paused"
+        case .breakRunning:
+            return "Break (Running)"
+        case .breakPaused:
+            return "Break (Paused)"
+        }
+    }
+}
+
+#Preview {
+    MainWindowView()
+        .environmentObject(AppState())
+}

--- a/macos/Pomodoro/Pomodoro/PomodoroApp.swift
+++ b/macos/Pomodoro/Pomodoro/PomodoroApp.swift
@@ -9,9 +9,12 @@ import SwiftUI
 
 @main
 struct PomodoroApp: App {
+    @StateObject private var appState = AppState()
+
     var body: some Scene {
         WindowGroup {
             ContentView()
+                .environmentObject(appState)
         }
     }
 }

--- a/macos/Pomodoro/Pomodoro/PomodoroTimerEngine.swift
+++ b/macos/Pomodoro/Pomodoro/PomodoroTimerEngine.swift
@@ -1,0 +1,116 @@
+//
+//  PomodoroTimerEngine.swift
+//  Pomodoro
+//
+//  Created by Zhengyang Hu on 1/15/26.
+//
+
+import Foundation
+
+final class PomodoroTimerEngine: ObservableObject {
+    enum State: String {
+        case idle
+        case running
+        case paused
+        case breakRunning
+        case breakPaused
+
+        var isOnBreak: Bool {
+            switch self {
+            case .breakRunning, .breakPaused:
+                return true
+            case .idle, .running, .paused:
+                return false
+            }
+        }
+
+        var isRunning: Bool {
+            self == .running || self == .breakRunning
+        }
+
+        var isPaused: Bool {
+            self == .paused || self == .breakPaused
+        }
+    }
+
+    @Published private(set) var state: State = .idle
+    @Published private(set) var remainingSeconds: Int
+
+    private let workDuration: Int
+    private let breakDuration: Int
+    private var timer: Timer?
+
+    init(workDuration: Int = 25 * 60, breakDuration: Int = 5 * 60) {
+        self.workDuration = workDuration
+        self.breakDuration = breakDuration
+        self.remainingSeconds = workDuration
+    }
+
+    func start() {
+        guard state == .idle else { return }
+        remainingSeconds = workDuration
+        state = .running
+        startTimer()
+    }
+
+    func pause() {
+        guard state.isRunning else { return }
+        state = state.isOnBreak ? .breakPaused : .paused
+        stopTimer()
+    }
+
+    func resume() {
+        guard state.isPaused else { return }
+        state = state.isOnBreak ? .breakRunning : .running
+        startTimer()
+    }
+
+    func reset() {
+        stopTimer()
+        state = .idle
+        remainingSeconds = workDuration
+    }
+
+    func skipBreak() {
+        guard state.isOnBreak else { return }
+        stopTimer()
+        state = .idle
+        remainingSeconds = workDuration
+    }
+
+    private func startTimer() {
+        stopTimer()
+        timer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
+            self?.tick()
+        }
+    }
+
+    private func stopTimer() {
+        timer?.invalidate()
+        timer = nil
+    }
+
+    private func tick() {
+        guard remainingSeconds > 0 else {
+            handleCompletion()
+            return
+        }
+
+        remainingSeconds -= 1
+
+        if remainingSeconds == 0 {
+            handleCompletion()
+        }
+    }
+
+    private func handleCompletion() {
+        if state.isOnBreak {
+            stopTimer()
+            state = .idle
+            remainingSeconds = workDuration
+        } else {
+            state = .breakRunning
+            remainingSeconds = breakDuration
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Centralize timer logic so the app has a single source of truth for all timers and to prepare for a menu-bar controller later. 
- Provide a correct, testable Pomodoro flow (work → break, skip, pause/resume/reset) plus an independent Countdown timer that may run simultaneously. 
- Keep all timing/transition logic out of views so state is observable and reusable across the app.

### Description
- Add `AppState` as an `ObservableObject` that owns `PomodoroTimerEngine` and `CountdownTimerEngine` and forwards their `objectWillChange` events to SwiftUI via `objectWillChange.send()`.
- Implement `PomodoroTimerEngine` with an explicit `State` enum and `start`, `pause`, `resume`, `reset`, and `skipBreak` intents, a single repeating `Timer` at 1s resolution, and correct work→break transitions.
- Implement `CountdownTimerEngine` with an explicit `State` enum and `start`, `pause`, `resume`, and `reset` intents, using a single repeating `Timer` at 1s resolution and independent lifecycle from Pomodoro.
- Add `MainWindowView` (minimal validation UI) that observes `AppState` and exposes buttons to exercise both engines, and wire `AppState` into the app via `ContentView` and `PomodoroApp` using `@StateObject`/`environmentObject`.

### Testing
- No automated tests were executed as part of this change.
- The source files were compiled and committed successfully in the working branch (no unit tests present or run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968ec3334c4832399bbdd386e597d5e)