### PR TITLE
Add AppKit status bar menu integration for Pomodoro timers

### DIFF
--- a/macos/Pomodoro/Pomodoro.xcodeproj/project.pbxproj
+++ b/macos/Pomodoro/Pomodoro.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		7C360D5A2F191F17007313D3 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C360D532F191F17007313D3 /* ContentView.swift */; };
 		7C360D5B2F191F17007313D3 /* MainWindowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C360D542F191F17007313D3 /* MainWindowView.swift */; };
 		7C360D5C2F191F17007313D3 /* PomodoroApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C360D552F191F17007313D3 /* PomodoroApp.swift */; };
+		7C360D6A2F191F17007313D3 /* MenuBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C360D692F191F17007313D3 /* MenuBarController.swift */; };
 		7C360D5D2F191F17007313D3 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 7C360D562F191F17007313D3 /* Assets.xcassets */; };
 /* End PBXBuildFile section */
 
@@ -24,6 +25,7 @@
 		7C360D532F191F17007313D3 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		7C360D542F191F17007313D3 /* MainWindowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainWindowView.swift; sourceTree = "<group>"; };
 		7C360D552F191F17007313D3 /* PomodoroApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PomodoroApp.swift; sourceTree = "<group>"; };
+		7C360D692F191F17007313D3 /* MenuBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarController.swift; sourceTree = "<group>"; };
 		7C360D562F191F17007313D3 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -70,6 +72,7 @@
 			isa = PBXGroup;
 			children = (
 				7C360D552F191F17007313D3 /* PomodoroApp.swift */,
+				7C360D692F191F17007313D3 /* MenuBarController.swift */,
 			);
 			name = App;
 			sourceTree = "<group>";
@@ -183,6 +186,7 @@
 				7C360D5A2F191F17007313D3 /* ContentView.swift in Sources */,
 				7C360D5B2F191F17007313D3 /* MainWindowView.swift in Sources */,
 				7C360D5C2F191F17007313D3 /* PomodoroApp.swift in Sources */,
+				7C360D6A2F191F17007313D3 /* MenuBarController.swift in Sources */,
 				7C360D572F191F17007313D3 /* AppState.swift in Sources */,
 				7C360D582F191F17007313D3 /* CountdownTimerEngine.swift in Sources */,
 				7C360D592F191F17007313D3 /* PomodoroTimerEngine.swift in Sources */,

--- a/macos/Pomodoro/Pomodoro/AppState.swift
+++ b/macos/Pomodoro/Pomodoro/AppState.swift
@@ -5,6 +5,7 @@
 //  Created by Zhengyang Hu on 1/15/26.
 //
 
+import AppKit
 import Combine
 import SwiftUI
 
@@ -12,6 +13,7 @@ final class AppState: ObservableObject {
     let pomodoro: PomodoroTimerEngine
     let countdown: CountdownTimerEngine
 
+    private var menuBarController: MenuBarController?
     private var cancellables: Set<AnyCancellable> = []
 
     init(
@@ -32,5 +34,58 @@ final class AppState: ObservableObject {
                 self?.objectWillChange.send()
             }
             .store(in: &cancellables)
+
+        menuBarController = MenuBarController(appState: self)
+    }
+
+    func startPomodoro() {
+        pomodoro.start()
+    }
+
+    func togglePomodoroPause() {
+        if pomodoro.state.isRunning {
+            pomodoro.pause()
+        } else if pomodoro.state.isPaused {
+            pomodoro.resume()
+        }
+    }
+
+    func resetPomodoro() {
+        pomodoro.reset()
+    }
+
+    func startBreak() {
+        pomodoro.startBreak()
+    }
+
+    func skipBreak() {
+        pomodoro.skipBreak()
+    }
+
+    func startCountdown() {
+        countdown.start()
+    }
+
+    func toggleCountdownPause() {
+        if countdown.state.isRunning {
+            countdown.pause()
+        } else if countdown.state.isPaused {
+            countdown.resume()
+        }
+    }
+
+    func resetCountdown() {
+        countdown.reset()
+    }
+
+    func openMainWindow() {
+        NSApplication.shared.activate(ignoringOtherApps: true)
+        if let window = NSApplication.shared.windows.first {
+            window.makeKeyAndOrderFront(nil)
+        }
+    }
+
+    func quitApp() {
+        NSApplication.shared.terminate(nil)
     }
 }

--- a/macos/Pomodoro/Pomodoro/MenuBarController.swift
+++ b/macos/Pomodoro/Pomodoro/MenuBarController.swift
@@ -1,0 +1,221 @@
+//
+//  MenuBarController.swift
+//  Pomodoro
+//
+//  Created by Zhengyang Hu on 1/15/26.
+//
+
+import AppKit
+import Combine
+
+final class MenuBarController {
+    private enum MenuMode {
+        case pomodoro
+        case breakTime
+        case countdown
+        case idle
+    }
+
+    private unowned let appState: AppState
+    private let statusItem: NSStatusItem
+    private var titleTimer: Timer?
+    private var cancellables: Set<AnyCancellable> = []
+
+    init(appState: AppState) {
+        self.appState = appState
+        statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
+        configureStatusItem()
+        observeStateChanges()
+        startTitleTimer()
+    }
+
+    deinit {
+        titleTimer?.invalidate()
+    }
+
+    private func configureStatusItem() {
+        if let button = statusItem.button {
+            button.attributedTitle = statusTitleAttributedString()
+        }
+        rebuildMenu()
+    }
+
+    private func observeStateChanges() {
+        appState.pomodoro.$state
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in
+                self?.rebuildMenu()
+                self?.updateTitle()
+            }
+            .store(in: &cancellables)
+
+        appState.countdown.$state
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in
+                self?.rebuildMenu()
+                self?.updateTitle()
+            }
+            .store(in: &cancellables)
+    }
+
+    private func startTitleTimer() {
+        titleTimer?.invalidate()
+        titleTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
+            self?.updateTitle()
+        }
+    }
+
+    private func updateTitle() {
+        guard let button = statusItem.button else { return }
+        button.attributedTitle = statusTitleAttributedString()
+        button.toolTip = statusTooltip()
+    }
+
+    private func statusTitleAttributedString() -> NSAttributedString {
+        let title = statusTitle()
+        let font = NSFont.monospacedDigitSystemFont(ofSize: NSFont.systemFontSize, weight: .regular)
+        return NSAttributedString(string: title, attributes: [.font: font])
+    }
+
+    private func statusTitle() -> String {
+        switch currentMenuMode() {
+        case .pomodoro:
+            return "🍅 \(formattedTime(appState.pomodoro.remainingSeconds))"
+        case .breakTime:
+            return "☕ \(formattedTime(appState.pomodoro.remainingSeconds))"
+        case .countdown:
+            return "⏱ \(formattedTime(appState.countdown.remainingSeconds))"
+        case .idle:
+            return "🍅 Ready"
+        }
+    }
+
+    private func statusTooltip() -> String {
+        switch currentMenuMode() {
+        case .pomodoro:
+            return "Pomodoro running"
+        case .breakTime:
+            return "Break running"
+        case .countdown:
+            return "Countdown running"
+        case .idle:
+            return "Idle"
+        }
+    }
+
+    private func currentMenuMode() -> MenuMode {
+        if appState.pomodoro.state == .running || appState.pomodoro.state == .paused {
+            return .pomodoro
+        }
+        if appState.pomodoro.state == .breakRunning || appState.pomodoro.state == .breakPaused {
+            return .breakTime
+        }
+        if appState.countdown.state != .idle {
+            return .countdown
+        }
+        return .idle
+    }
+
+    private func rebuildMenu() {
+        let menu = NSMenu()
+
+        switch currentMenuMode() {
+        case .pomodoro:
+            menu.addItem(sectionHeader(title: "Pomodoro — Work"))
+            menu.addItem(.separator())
+            menu.addItem(actionItem(title: "⏸ Pause", action: #selector(pausePomodoro)))
+            menu.addItem(actionItem(title: "↺ Reset", action: #selector(resetPomodoro)))
+            menu.addItem(.separator())
+            menu.addItem(actionItem(title: "Start Break", action: #selector(startBreak)))
+            menu.addItem(.separator())
+            menu.addItem(actionItem(title: "Open App", action: #selector(openApp)))
+            menu.addItem(actionItem(title: "Quit", action: #selector(quitApp)))
+        case .breakTime:
+            menu.addItem(sectionHeader(title: "Break Time"))
+            menu.addItem(.separator())
+            menu.addItem(actionItem(title: "⏸ Pause", action: #selector(pausePomodoro)))
+            menu.addItem(actionItem(title: "↺ Reset", action: #selector(resetPomodoro)))
+            menu.addItem(.separator())
+            menu.addItem(actionItem(title: "Skip Break", action: #selector(skipBreak)))
+            menu.addItem(.separator())
+            menu.addItem(actionItem(title: "Open App", action: #selector(openApp)))
+            menu.addItem(actionItem(title: "Quit", action: #selector(quitApp)))
+        case .countdown:
+            menu.addItem(sectionHeader(title: "Countdown Timer"))
+            menu.addItem(.separator())
+            menu.addItem(actionItem(title: "⏸ Pause", action: #selector(pauseCountdown)))
+            menu.addItem(actionItem(title: "↺ Reset", action: #selector(resetCountdown)))
+            menu.addItem(.separator())
+            menu.addItem(actionItem(title: "Open App", action: #selector(openApp)))
+            menu.addItem(actionItem(title: "Quit", action: #selector(quitApp)))
+        case .idle:
+            menu.addItem(sectionHeader(title: "Pomodoro Timer"))
+            menu.addItem(actionItem(title: "Start Pomodoro", action: #selector(startPomodoro)))
+            menu.addItem(actionItem(title: "Start Countdown", action: #selector(startCountdown)))
+            menu.addItem(.separator())
+            menu.addItem(actionItem(title: "Open App", action: #selector(openApp)))
+            menu.addItem(actionItem(title: "Quit", action: #selector(quitApp)))
+        }
+
+        statusItem.menu = menu
+    }
+
+    private func sectionHeader(title: String) -> NSMenuItem {
+        let item = NSMenuItem(title: title, action: nil, keyEquivalent: "")
+        item.isEnabled = false
+        return item
+    }
+
+    private func actionItem(title: String, action: Selector) -> NSMenuItem {
+        let item = NSMenuItem(title: title, action: action, keyEquivalent: "")
+        item.target = self
+        return item
+    }
+
+    private func formattedTime(_ seconds: Int) -> String {
+        let clampedSeconds = max(0, seconds)
+        let minutes = clampedSeconds / 60
+        let remaining = clampedSeconds % 60
+        return String(format: "%02d:%02d", minutes, remaining)
+    }
+
+    @objc private func startPomodoro() {
+        appState.startPomodoro()
+    }
+
+    @objc private func pausePomodoro() {
+        appState.togglePomodoroPause()
+    }
+
+    @objc private func resetPomodoro() {
+        appState.resetPomodoro()
+    }
+
+    @objc private func startBreak() {
+        appState.startBreak()
+    }
+
+    @objc private func skipBreak() {
+        appState.skipBreak()
+    }
+
+    @objc private func startCountdown() {
+        appState.startCountdown()
+    }
+
+    @objc private func pauseCountdown() {
+        appState.toggleCountdownPause()
+    }
+
+    @objc private func resetCountdown() {
+        appState.resetCountdown()
+    }
+
+    @objc private func openApp() {
+        appState.openMainWindow()
+    }
+
+    @objc private func quitApp() {
+        appState.quitApp()
+    }
+}

--- a/macos/Pomodoro/Pomodoro/PomodoroTimerEngine.swift
+++ b/macos/Pomodoro/Pomodoro/PomodoroTimerEngine.swift
@@ -79,6 +79,14 @@ final class PomodoroTimerEngine: ObservableObject {
         remainingSeconds = workDuration
     }
 
+    func startBreak() {
+        guard state == .running || state == .paused else { return }
+        stopTimer()
+        state = .breakRunning
+        remainingSeconds = breakDuration
+        startTimer()
+    }
+
     private func startTimer() {
         stopTimer()
         timer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in


### PR DESCRIPTION
### Motivation
- Provide a native macOS status bar item that reflects and controls timers independently of the main window.
- Keep timer logic in existing engines and use `AppState` as the single source of truth so the menu stays in sync with the app.

### Description
- Add an AppKit `MenuBarController` in `macos/Pomodoro/Pomodoro/MenuBarController.swift` that creates an `NSStatusItem`, updates a monospaced digit title once per second, observes `AppState`, and builds the exact native `NSMenu` layouts required for each timer state.
- Wire the menu actions through new `AppState` helper methods in `macos/Pomodoro/Pomodoro/AppState.swift`, and instantiate the `MenuBarController` from `AppState` so it is created at launch because `AppState` is a `@StateObject` in `PomodoroApp`.
- Add `startBreak()` to `PomodoroTimerEngine` in `macos/Pomodoro/Pomodoro/PomodoroTimerEngine.swift` so the menu can trigger a break without changing core timer behavior.
- Add the new source to the Xcode project `macos/Pomodoro/Pomodoro.xcodeproj/project.pbxproj` so the file is compiled with the app.

### Testing
- No automated tests were executed as part of this change.
- Manual verification notes: the status title updates once per second using a single scheduled `Timer` (the controller invalidates any existing timer before scheduling), and the menu is rebuilt only on `AppState` changes to avoid per-second menu rebuilds.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968f5d4adcc832386818b968d0dc7af)