### PR TITLE
Polish menu bar lifecycle and window handling

### DIFF
--- a/macos/Pomodoro/Pomodoro/AppDelegate.swift
+++ b/macos/Pomodoro/Pomodoro/AppDelegate.swift
@@ -1,0 +1,72 @@
+//
+//  AppDelegate.swift
+//  Pomodoro
+//
+//  Created by Zhengyang Hu on 1/15/26.
+//
+
+import AppKit
+import SwiftUI
+
+final class AppDelegate: NSObject, NSApplicationDelegate {
+    private weak var mainWindow: NSWindow?
+
+    var appState: AppState? {
+        didSet {
+            appState?.openWindowHandler = { [weak self] in
+                self?.openMainWindow()
+            }
+        }
+    }
+
+    func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
+        false
+    }
+
+    func applicationWillTerminate(_ notification: Notification) {
+        appState?.shutdown()
+    }
+
+    func openMainWindow() {
+        guard let appState else { return }
+
+        if let window = mainWindow ?? existingWindow() {
+            focus(window: window)
+            return
+        }
+
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 480, height: 320),
+            styleMask: [.titled, .closable, .miniaturizable, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+        window.title = "Pomodoro"
+        window.isReleasedWhenClosed = true
+        window.contentViewController = NSHostingController(
+            rootView: ContentView().environmentObject(appState)
+        )
+        window.center()
+        window.makeKeyAndOrderFront(nil)
+        focus(window: window)
+        mainWindow = window
+    }
+
+    private func existingWindow() -> NSWindow? {
+        let window = NSApplication.shared.windows.first { window in
+            window.isVisible || window.isMiniaturized
+        }
+        if let window {
+            mainWindow = window
+        }
+        return window
+    }
+
+    private func focus(window: NSWindow) {
+        NSApplication.shared.activate(ignoringOtherApps: true)
+        if window.isMiniaturized {
+            window.deminiaturize(nil)
+        }
+        window.makeKeyAndOrderFront(nil)
+    }
+}

--- a/macos/Pomodoro/Pomodoro/AppState.swift
+++ b/macos/Pomodoro/Pomodoro/AppState.swift
@@ -13,7 +13,9 @@ final class AppState: ObservableObject {
     let pomodoro: PomodoroTimerEngine
     let countdown: CountdownTimerEngine
 
-    private var menuBarController: MenuBarController?
+    var openWindowHandler: (() -> Void)?
+
+    private let menuBarController: MenuBarController
     private var cancellables: Set<AnyCancellable> = []
 
     init(
@@ -79,6 +81,11 @@ final class AppState: ObservableObject {
     }
 
     func openMainWindow() {
+        if let openWindowHandler {
+            openWindowHandler()
+            return
+        }
+
         NSApplication.shared.activate(ignoringOtherApps: true)
         if let window = NSApplication.shared.windows.first {
             window.makeKeyAndOrderFront(nil)
@@ -87,5 +94,9 @@ final class AppState: ObservableObject {
 
     func quitApp() {
         NSApplication.shared.terminate(nil)
+    }
+
+    func shutdown() {
+        menuBarController.shutdown()
     }
 }

--- a/macos/Pomodoro/Pomodoro/PomodoroApp.swift
+++ b/macos/Pomodoro/Pomodoro/PomodoroApp.swift
@@ -9,7 +9,14 @@ import SwiftUI
 
 @main
 struct PomodoroApp: App {
-    @StateObject private var appState = AppState()
+    @NSApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
+    @StateObject private var appState: AppState
+
+    init() {
+        let state = AppState()
+        _appState = StateObject(wrappedValue: state)
+        appDelegate.appState = state
+    }
 
     var body: some Scene {
         WindowGroup {


### PR DESCRIPTION
### Motivation
- Keep the app running after all windows are closed and ensure the status item remains visible so the app behaves like a native macOS utility. 
- Prevent duplicate windows, status items, and timers while making menu bar updates feel immediate and responsive. 
- Centralize lifecycle and cleanup so quitting only happens via the menu `Quit` or `Cmd+Q` and resources are released on termination.

### Description
- Add an `AppDelegate` (`AppDelegate.swift`) and wire it into the SwiftUI app via `@NSApplicationDelegateAdaptor`, with `applicationShouldTerminateAfterLastWindowClosed` returning `false` and an `openMainWindow()` implementation that reuses an existing window or creates one only when needed. 
- Change `PomodoroApp` to create a single `AppState` in `init()` and assign it to the `AppDelegate` so window open requests are routed through `AppDelegate`. 
- Wire `AppState` to accept an `openWindowHandler` and expose a `shutdown()` call; `AppState` still owns a single `MenuBarController`. 
- Harden `MenuBarController`: make it `NSObject` + `NSMenuDelegate`, keep one `NSMenu` instance, call `rebuildMenu()` on `menuWillOpen(_:)` instead of rebuilding every second, provide dynamic pause/resume titles, run a lightweight title `Timer` for the status title only, and add a `shutdown()` to invalidate timers, cancel observers, and remove the status item to avoid duplicates. 
- Window management decisions: `AppDelegate` holds a `weak mainWindow`, searches `NSApplication.shared.windows` for visible/miniaturized windows to avoid creating duplicates, and uses `activate`/`makeKeyAndOrderFront`/`deminiaturize` to bring windows to front without flicker. 

### Testing
- No automated tests were run on these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968f86c38a08323bbb52605afdd5c22)