### PR TITLE
Fix menu bar controller initialization order and decouple AppState from UI

### DIFF
--- a/macos/PomodoroApp/AppState.swift
+++ b/macos/PomodoroApp/AppState.swift
@@ -1,25 +1,5 @@
-import AppKit
 import SwiftUI
 
 final class AppState: ObservableObject {
-    private let menuBarController: MenuBarController
-
-    init() {
-        menuBarController = MenuBarController(
-            openMainWindow: { [weak self] in
-                self?.focusMainWindow()
-            },
-            quit: {
-                NSApplication.shared.terminate(nil)
-            }
-        )
-    }
-
-    func focusMainWindow() {
-        NSApplication.shared.activate(ignoringOtherApps: true)
-
-        if let window = NSApplication.shared.windows.first {
-            window.makeKeyAndOrderFront(nil)
-        }
-    }
+    init() {}
 }

--- a/macos/PomodoroApp/MenuBarController.swift
+++ b/macos/PomodoroApp/MenuBarController.swift
@@ -1,15 +1,30 @@
 import AppKit
+import Combine
 
 final class MenuBarController {
+    private let appState: AppState
     private let statusItem: NSStatusItem
     private let openMainWindow: () -> Void
     private let quit: () -> Void
+    private var stateObserver: AnyCancellable?
 
-    init(openMainWindow: @escaping () -> Void, quit: @escaping () -> Void) {
+    init(appState: AppState, openMainWindow: @escaping () -> Void, quit: @escaping () -> Void) {
+        self.appState = appState
         self.openMainWindow = openMainWindow
         self.quit = quit
         statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
+        observeAppState()
         configureStatusItem()
+    }
+
+    private func observeAppState() {
+        stateObserver = appState.objectWillChange.sink { [weak self] in
+            self?.handleStateChange()
+        }
+    }
+
+    private func handleStateChange() {
+        // No-op for now; observing keeps menu in sync when state changes are added.
     }
 
     private func configureStatusItem() {

--- a/macos/PomodoroApp/PomodoroApp.swift
+++ b/macos/PomodoroApp/PomodoroApp.swift
@@ -1,13 +1,32 @@
+import AppKit
 import SwiftUI
 
 @main
 struct PomodoroApp: App {
     @StateObject private var appState = AppState()
+    @State private var menuBarController: MenuBarController?
 
     var body: some Scene {
         WindowGroup {
             MainWindowView()
                 .environmentObject(appState)
+                .task {
+                    if menuBarController == nil {
+                        menuBarController = MenuBarController(
+                            appState: appState,
+                            openMainWindow: focusMainWindow,
+                            quit: { NSApplication.shared.terminate(nil) }
+                        )
+                    }
+                }
+        }
+    }
+
+    private func focusMainWindow() {
+        NSApplication.shared.activate(ignoringOtherApps: true)
+
+        if let window = NSApplication.shared.windows.first {
+            window.makeKeyAndOrderFront(nil)
         }
     }
 }


### PR DESCRIPTION
### Motivation
- Fix compile errors caused by creating `MenuBarController` inside `AppState`, which referenced `self` before all stored properties were initialized.
- Keep `AppState` as pure state/logic without AppKit/UI ownership and ensure `MenuBarController` receives state via dependency injection and may observe it.

### Description
- Remove `AppKit` usage and all `MenuBarController` ownership from `AppState`, leaving `AppState.init()` empty so it remains a pure `ObservableObject`.
- Change `MenuBarController` to `init(appState: AppState, openMainWindow: @escaping () -> Void, quit: @escaping () -> Void)` and add a `Combine` subscription to `appState.objectWillChange` to observe state changes.
- Create the `MenuBarController` after `AppState` is initialized in `PomodoroApp` using a `@State` `menuBarController` and a `.task {}` attached to the `WindowGroup` content, and move `focusMainWindow()` into `PomodoroApp` so closures do not capture `self` prematurely.

### Testing
- No automated tests were run on the modified code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969006e956883239976c510c3aa3403)