### PR TITLE
Remove MenuBarController from AppState and instantiate it in AppDelegate with injected handlers

### DIFF
--- a/macos/Pomodoro/Pomodoro/AppDelegate.swift
+++ b/macos/Pomodoro/Pomodoro/AppDelegate.swift
@@ -11,15 +11,22 @@ import SwiftUI
 final class AppDelegate: NSObject, NSApplicationDelegate {
     private weak var mainWindow: NSWindow?
     private var appStateConfigured = false
+    private var menuBarController: MenuBarController?
 
     var appState: AppState? {
         didSet {
             guard !appStateConfigured else { return }
             guard let appState else { return }
             appStateConfigured = true
-            appState.openWindowHandler = { [weak self] in
-                self?.openMainWindow()
-            }
+            menuBarController = MenuBarController(
+                appState: appState,
+                openMainWindow: { [weak self] in
+                    self?.openMainWindow()
+                },
+                quitApp: { [weak self] in
+                    self?.quitApp()
+                }
+            )
         }
     }
 
@@ -28,7 +35,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func applicationWillTerminate(_ notification: Notification) {
-        appState?.shutdown()
+        menuBarController?.shutdown()
     }
 
     func openMainWindow() {
@@ -54,6 +61,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         window.makeKeyAndOrderFront(nil)
         focus(window: window)
         mainWindow = window
+    }
+
+    private func quitApp() {
+        NSApplication.shared.terminate(nil)
     }
 
     private func existingWindow() -> NSWindow? {

--- a/macos/Pomodoro/Pomodoro/AppState.swift
+++ b/macos/Pomodoro/Pomodoro/AppState.swift
@@ -5,7 +5,6 @@
 //  Created by Zhengyang Hu on 1/15/26.
 //
 
-import AppKit
 import Combine
 import SwiftUI
 
@@ -13,9 +12,6 @@ final class AppState: ObservableObject {
     let pomodoro: PomodoroTimerEngine
     let countdown: CountdownTimerEngine
 
-    var openWindowHandler: (() -> Void)?
-
-    private let menuBarController: MenuBarController
     private var cancellables: Set<AnyCancellable> = []
 
     init(
@@ -37,7 +33,6 @@ final class AppState: ObservableObject {
             }
             .store(in: &cancellables)
 
-        menuBarController = MenuBarController(appState: self)
     }
 
     func startPomodoro() {
@@ -80,23 +75,4 @@ final class AppState: ObservableObject {
         countdown.reset()
     }
 
-    func openMainWindow() {
-        if let openWindowHandler {
-            openWindowHandler()
-            return
-        }
-
-        NSApplication.shared.activate(ignoringOtherApps: true)
-        if let window = NSApplication.shared.windows.first {
-            window.makeKeyAndOrderFront(nil)
-        }
-    }
-
-    func quitApp() {
-        NSApplication.shared.terminate(nil)
-    }
-
-    func shutdown() {
-        menuBarController.shutdown()
-    }
 }

--- a/macos/Pomodoro/Pomodoro/MenuBarController.swift
+++ b/macos/Pomodoro/Pomodoro/MenuBarController.swift
@@ -19,11 +19,15 @@ final class MenuBarController: NSObject, NSMenuDelegate {
     private unowned let appState: AppState
     private let statusItem: NSStatusItem
     private let menu: NSMenu
+    private let openMainWindow: () -> Void
+    private let quitHandler: () -> Void
     private var titleTimer: Timer?
     private var cancellables: Set<AnyCancellable> = []
 
-    init(appState: AppState) {
+    init(appState: AppState, openMainWindow: @escaping () -> Void, quitApp: @escaping () -> Void) {
         self.appState = appState
+        self.openMainWindow = openMainWindow
+        self.quitHandler = quitApp
         statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
         menu = NSMenu()
         menu.autoenablesItems = false
@@ -225,11 +229,11 @@ final class MenuBarController: NSObject, NSMenuDelegate {
     }
 
     @objc private func openApp() {
-        appState.openMainWindow()
+        openMainWindow()
     }
 
     @objc private func quitApp() {
-        appState.quitApp()
+        quitHandler()
     }
 
     func menuWillOpen(_ menu: NSMenu) {


### PR DESCRIPTION
### Motivation
- AppState illegally owned and initialized `MenuBarController` and imported `AppKit`, causing Swift initialization-order violations and mixing UI with pure state.
- The change enforces a clean separation so AppState remains pure state (timers + data) with no UI side effects or AppKit dependencies.
- MenuBarController must be created after AppState exists and observe AppState via dependency injection to avoid use-of-`self` during initialization.

### Description
- Removed `AppKit` import, the `menuBarController` property, and all UI methods/handlers from `AppState`, leaving it as a pure state holder with timer engines and Combine wiring only.
- Changed `MenuBarController` initializer to `init(appState:openMainWindow:quitApp:)`, added injected `openMainWindow` and `quitHandler` callbacks, and replaced calls to UI methods on `AppState` with those injected handlers.
- Created and stored `MenuBarController` in `AppDelegate` after `appState` is set, and wired `openMainWindow` and `quitApp` handlers there; `AppDelegate` now calls `menuBarController?.shutdown()` on termination.
- This redesign keeps all UI/AppKit work out of AppState and ensures the initialization order is: create `AppState` first, then create `MenuBarController` using the already-initialized `AppState`.

### Testing
- No automated tests were run as part of this change.
- Code changes were inspected and verified to remove the previous illegal reference to `MenuBarController` from `AppState` and to relocate menu bar creation to `AppDelegate`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969021cf180832394fb35d7a6e5b162)