### PR TITLE
Fix MenuBarController initialization order

### DIFF
--- a/macos/Pomodoro/Pomodoro/MenuBarController.swift
+++ b/macos/Pomodoro/Pomodoro/MenuBarController.swift
@@ -31,6 +31,7 @@ final class MenuBarController: NSObject, NSMenuDelegate {
         statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
         menu = NSMenu()
         menu.autoenablesItems = false
+        super.init()
         configureStatusItem()
         observeStateChanges()
         startTitleTimer()


### PR DESCRIPTION
### Motivation
- Ensure all stored properties are assigned and `super.init()` is called before any instance method that uses `self` to resolve Swift initialization-order errors related to calling `configureStatusItem()`, `observeStateChanges()`, and `startTitleTimer()` from the initializer. 

### Description
- Call `super.init()` immediately after assigning all stored properties in `MenuBarController.init(...)` so that `configureStatusItem()`, `observeStateChanges()`, and `startTitleTimer()` are invoked only after superclass initialization. 

### Testing
- No automated tests or builds were executed in this environment, so no test results to report; the initialization-order change is limited to one-line insertion of `super.init()` and addresses the compiler errors previously reported.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696907296930832393bbad334254e114)