### PR TITLE
Add configurable durations and long-break cadence to Pomodoro engine

### DIFF
--- a/macos/Pomodoro/Pomodoro/AppState.swift
+++ b/macos/Pomodoro/Pomodoro/AppState.swift
@@ -12,14 +12,39 @@ final class AppState: ObservableObject {
     let pomodoro: PomodoroTimerEngine
     let countdown: CountdownTimerEngine
 
+    @Published var workDuration: Int {
+        didSet { updatePomodoroConfiguration() }
+    }
+    @Published var breakDuration: Int {
+        didSet { updatePomodoroConfiguration() }
+    }
+    @Published var longBreakDuration: Int {
+        didSet { updatePomodoroConfiguration() }
+    }
+    @Published var sessionsUntilLongBreak: Int {
+        didSet { updatePomodoroConfiguration() }
+    }
+
+    var pomodoroMode: PomodoroTimerEngine.Mode {
+        pomodoro.mode
+    }
+
     private var cancellables: Set<AnyCancellable> = []
 
     init(
         pomodoro: PomodoroTimerEngine = PomodoroTimerEngine(),
-        countdown: CountdownTimerEngine = CountdownTimerEngine()
+        countdown: CountdownTimerEngine = CountdownTimerEngine(),
+        workDuration: Int = 25 * 60,
+        breakDuration: Int = 5 * 60,
+        longBreakDuration: Int = 15 * 60,
+        sessionsUntilLongBreak: Int = 4
     ) {
         self.pomodoro = pomodoro
         self.countdown = countdown
+        self.workDuration = workDuration
+        self.breakDuration = breakDuration
+        self.longBreakDuration = longBreakDuration
+        self.sessionsUntilLongBreak = sessionsUntilLongBreak
 
         pomodoro.objectWillChange
             .sink { [weak self] _ in
@@ -33,6 +58,16 @@ final class AppState: ObservableObject {
             }
             .store(in: &cancellables)
 
+        updatePomodoroConfiguration()
+    }
+
+    private func updatePomodoroConfiguration() {
+        pomodoro.updateConfiguration(
+            workDuration: workDuration,
+            breakDuration: breakDuration,
+            longBreakDuration: longBreakDuration,
+            sessionsUntilLongBreak: sessionsUntilLongBreak
+        )
     }
 
     func startPomodoro() {

--- a/macos/Pomodoro/Pomodoro/MainWindowView.swift
+++ b/macos/Pomodoro/Pomodoro/MainWindowView.swift
@@ -13,7 +13,7 @@ struct MainWindowView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
             VStack(alignment: .leading, spacing: 8) {
-                Text(appState.pomodoro.state.isOnBreak ? "Break" : "Pomodoro")
+                Text(titleForPomodoroMode(appState.pomodoroMode))
                     .font(.headline)
                 Text(formattedTime(appState.pomodoro.remainingSeconds))
                     .font(.title)
@@ -88,6 +88,17 @@ struct MainWindowView: View {
             return "Break (Running)"
         case .breakPaused:
             return "Break (Paused)"
+        }
+    }
+
+    private func titleForPomodoroMode(_ mode: PomodoroTimerEngine.Mode) -> String {
+        switch mode {
+        case .work:
+            return "Pomodoro"
+        case .breakTime:
+            return "Break"
+        case .longBreak:
+            return "Long Break"
         }
     }
 }

--- a/macos/Pomodoro/Pomodoro/MenuBarController.swift
+++ b/macos/Pomodoro/Pomodoro/MenuBarController.swift
@@ -92,7 +92,7 @@ final class MenuBarController: NSObject, NSMenuDelegate {
         case .pomodoro:
             return "🍅 \(formattedTime(appState.pomodoro.remainingSeconds))"
         case .breakTime:
-            return "☕ \(formattedTime(appState.pomodoro.remainingSeconds))"
+            return "\(breakEmoji()) \(formattedTime(appState.pomodoro.remainingSeconds))"
         case .countdown:
             return "⏱ \(formattedTime(appState.countdown.remainingSeconds))"
         case .idle:
@@ -105,7 +105,7 @@ final class MenuBarController: NSObject, NSMenuDelegate {
         case .pomodoro:
             return "Pomodoro running"
         case .breakTime:
-            return "Break running"
+            return breakTooltip()
         case .countdown:
             return "Countdown running"
         case .idle:
@@ -141,7 +141,7 @@ final class MenuBarController: NSObject, NSMenuDelegate {
             menu.addItem(actionItem(title: "Open App", action: #selector(openApp)))
             menu.addItem(actionItem(title: "Quit", action: #selector(quitApp)))
         case .breakTime:
-            menu.addItem(sectionHeader(title: "Break Time"))
+            menu.addItem(sectionHeader(title: breakMenuTitle()))
             menu.addItem(.separator())
             menu.addItem(actionItem(title: pomodoroPauseTitle(), action: #selector(pausePomodoro)))
             menu.addItem(actionItem(title: "↺ Reset", action: #selector(resetPomodoro)))
@@ -191,6 +191,18 @@ final class MenuBarController: NSObject, NSMenuDelegate {
 
     private func pomodoroPauseTitle() -> String {
         appState.pomodoro.state.isPaused ? "▶ Resume" : "⏸ Pause"
+    }
+
+    private func breakMenuTitle() -> String {
+        appState.pomodoroMode == .longBreak ? "Long Break" : "Break Time"
+    }
+
+    private func breakTooltip() -> String {
+        appState.pomodoroMode == .longBreak ? "Long break running" : "Break running"
+    }
+
+    private func breakEmoji() -> String {
+        appState.pomodoroMode == .longBreak ? "🌙" : "☕"
     }
 
     private func countdownPauseTitle() -> String {


### PR DESCRIPTION
### Motivation
- Provide user-configurable durations and a long-break cadence so the timer can support custom work/break/long-break intervals.
- Surface the current Pomodoro mode (Work / Break / LongBreak) through the central state so UI and menu bar can react without owning timer logic.

### Description
- Added configurable properties to `AppState` (`workDuration`, `breakDuration`, `longBreakDuration`, `sessionsUntilLongBreak`) and exposed the current mode via `pomodoroMode` which proxies `PomodoroTimerEngine.mode`.
- Extended `PomodoroTimerEngine` with a `Mode` enum, `longBreakDuration`, `sessionsUntilLongBreak`, a `completedWorkSessions` counter, and `updateConfiguration(...)` to accept runtime configuration from `AppState` while keeping timer logic in the engine.
- Implemented long-break cadence: each completed work session increments `completedWorkSessions`, `isLongBreakDue()` returns true when the count reaches `sessionsUntilLongBreak`, and `beginBreak(isLongBreak:)` sets the `mode` and appropriate break duration; the cycle resets `completedWorkSessions` to 0 after a long break completes or is skipped.
- Updated UI labels in `MainWindowView` and `MenuBarController` to reflect `Long Break` state and to show different emoji/tooltip/title for long breaks without changing timer ownership or UI design.

### Testing
- No automated tests were executed as part of this change (no test suite run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a5f1e29448323a533ea28dee64192)