### PR TITLE
Fix AppState initializer linkage by removing default-argument thunks

### DIFF
--- a/macos/Pomodoro/Pomodoro/AppState.swift
+++ b/macos/Pomodoro/Pomodoro/AppState.swift
@@ -32,12 +32,12 @@ final class AppState: ObservableObject {
     private var cancellables: Set<AnyCancellable> = []
 
     init(
-        pomodoro: PomodoroTimerEngine = PomodoroTimerEngine(),
-        countdown: CountdownTimerEngine = CountdownTimerEngine(),
-        workDuration: Int = 25 * 60,
-        breakDuration: Int = 5 * 60,
-        longBreakDuration: Int = 15 * 60,
-        sessionsUntilLongBreak: Int = 4
+        pomodoro: PomodoroTimerEngine,
+        countdown: CountdownTimerEngine,
+        workDuration: Int,
+        breakDuration: Int,
+        longBreakDuration: Int,
+        sessionsUntilLongBreak: Int
     ) {
         self.pomodoro = pomodoro
         self.countdown = countdown
@@ -59,6 +59,17 @@ final class AppState: ObservableObject {
             .store(in: &cancellables)
 
         updatePomodoroConfiguration()
+    }
+
+    convenience init() {
+        self.init(
+            pomodoro: PomodoroTimerEngine(),
+            countdown: CountdownTimerEngine(),
+            workDuration: 25 * 60,
+            breakDuration: 5 * 60,
+            longBreakDuration: 15 * 60,
+            sessionsUntilLongBreak: 4
+        )
     }
 
     private func updatePomodoroConfiguration() {


### PR DESCRIPTION
### Motivation
- The app was failing to link with undefined symbols referencing default-argument thunks for `AppState.init(...)`, which can occur after refactors or target/migration changes and prevents the app from linking and running.
- `AppState.swift` is included in the `Pomodoro` target in the project file, so the simplest fix is to avoid compiler-generated default-argument symbols that were not being resolved.

### Description
- Removed default argument values from the designated initializer in `macos/Pomodoro/Pomodoro/AppState.swift` and added a `convenience init()` that forwards the original default values to preserve behavior.
- The change keeps all initialization logic intact and preserves the public callsite behavior for `AppState()` while avoiding default-argument thunk symbols that caused the linker error.
- Modified file: `macos/Pomodoro/Pomodoro/AppState.swift`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b25cde41c8323b2110e9441288f1a)