### PR TITLE
Add default-argument convenience initializer to AppState to fix linker error

### DIFF
--- a/macos/Pomodoro/Pomodoro/AppState.swift
+++ b/macos/Pomodoro/Pomodoro/AppState.swift
@@ -61,15 +61,22 @@ final class AppState: ObservableObject {
         updatePomodoroConfiguration()
     }
 
-    convenience init() {
+    convenience init(
+        pomodoro: PomodoroTimerEngine = PomodoroTimerEngine(),
+        countdown: CountdownTimerEngine = CountdownTimerEngine()
+    ) {
         self.init(
-            pomodoro: PomodoroTimerEngine(),
-            countdown: CountdownTimerEngine(),
+            pomodoro: pomodoro,
+            countdown: countdown,
             workDuration: 25 * 60,
             breakDuration: 5 * 60,
             longBreakDuration: 15 * 60,
             sessionsUntilLongBreak: 4
         )
+    }
+
+    convenience init() {
+        self.init(pomodoro: PomodoroTimerEngine(), countdown: CountdownTimerEngine())
     }
 
     private func updatePomodoroConfiguration() {


### PR DESCRIPTION
### Motivation
- Restore missing default-argument symbols that caused linker errors for `AppState.init(pomodoro:countdown:)` after recent refactors. 
- Ensure the zero-argument initializer continues to provide the same default timer engines while letting the compiler emit the required default-argument symbols. 

### Description
- Added a two-parameter convenience initializer with default values in `macos/Pomodoro/Pomodoro/AppState.swift` as `convenience init(pomodoro: PomodoroTimerEngine = PomodoroTimerEngine(), countdown: CountdownTimerEngine = CountdownTimerEngine())` to generate the missing default-argument symbols. 
- Updated the existing no-argument `convenience init()` to delegate to the new two-parameter initializer for consistent defaults. 
- Kept the designated initializer signature and implementation unchanged. 

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b3d1836cc83238ba50a7f79d834a7)