### PR TITLE
Expose pomodoro mode on AppState

### DIFF
--- a/macos/Pomodoro/Pomodoro/AppState.swift
+++ b/macos/Pomodoro/Pomodoro/AppState.swift
@@ -25,9 +25,7 @@ final class AppState: ObservableObject {
         didSet { updatePomodoroConfiguration() }
     }
 
-    var pomodoroMode: PomodoroTimerEngine.Mode {
-        pomodoro.mode
-    }
+    @Published private(set) var pomodoroMode: PomodoroTimerEngine.Mode
 
     private var cancellables: Set<AnyCancellable> = []
 
@@ -45,10 +43,18 @@ final class AppState: ObservableObject {
         self.breakDuration = breakDuration
         self.longBreakDuration = longBreakDuration
         self.sessionsUntilLongBreak = sessionsUntilLongBreak
+        self.pomodoroMode = pomodoro.mode
 
         pomodoro.objectWillChange
             .sink { [weak self] _ in
                 self?.objectWillChange.send()
+            }
+            .store(in: &cancellables)
+
+        pomodoro.$mode
+            .removeDuplicates()
+            .sink { [weak self] mode in
+                self?.pomodoroMode = mode
             }
             .store(in: &cancellables)
 


### PR DESCRIPTION
### Motivation
- Make the current pomodoro mode observable from `AppState` so the UI and menu bar can react to `Work`/`Break`/`LongBreak` mode changes without moving timer logic or duplicating behavior.

### Description
- Publish `pomodoroMode` as `@Published private(set) var` on `AppState`, initialize it from `pomodoro.mode`, and subscribe to `pomodoro.$mode` (with `removeDuplicates()`) to keep it in sync while leaving all timer cadence logic in `PomodoroTimerEngine`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b40c08a388323b985ef8cf1494317)