### PR TITLE
Implement long-break cadence and expose currentMode

### DIFF
--- a/macos/Pomodoro/Pomodoro/AppState.swift
+++ b/macos/Pomodoro/Pomodoro/AppState.swift
@@ -26,6 +26,7 @@ final class AppState: ObservableObject {
     }
 
     @Published private(set) var pomodoroMode: PomodoroTimerEngine.Mode
+    @Published private(set) var pomodoroCurrentMode: PomodoroTimerEngine.CurrentMode
 
     private var cancellables: Set<AnyCancellable> = []
 
@@ -44,6 +45,7 @@ final class AppState: ObservableObject {
         self.longBreakDuration = longBreakDuration
         self.sessionsUntilLongBreak = sessionsUntilLongBreak
         self.pomodoroMode = pomodoro.mode
+        self.pomodoroCurrentMode = pomodoro.currentMode
 
         pomodoro.objectWillChange
             .sink { [weak self] _ in
@@ -55,6 +57,13 @@ final class AppState: ObservableObject {
             .removeDuplicates()
             .sink { [weak self] mode in
                 self?.pomodoroMode = mode
+            }
+            .store(in: &cancellables)
+
+        pomodoro.$currentMode
+            .removeDuplicates()
+            .sink { [weak self] mode in
+                self?.pomodoroCurrentMode = mode
             }
             .store(in: &cancellables)
 


### PR DESCRIPTION
### Motivation
- Implement a long-break cadence so the engine tracks completed work sessions and turns every Nth break into a long break.
- Expose a stable `currentMode` that represents `idle`/`work`/`break`/`longBreak` for UI and observers.
- Ensure cadence resets after a long break and when long breaks are skipped, without changing UI code.

### Description
- Added `CurrentMode` enum (`idle`, `work`, `break`, `longBreak`) and a `@Published` `currentMode` to `PomodoroTimerEngine` to represent the observable, high-level mode.
- Added `@Published` `completedWorkSessions` and cadence-aware logic so completed work sessions increment on work completion and a long break is triggered when `completedWorkSessions >= sessionsUntilLongBreak`.
- Reset `completedWorkSessions` to `0` when a long break begins or completes (including when a long break is skipped) and updated `startBreak` to decide long vs short break using `isLongBreakDue()`.
- Introduced `updateCurrentMode()` and invoked it on relevant state transitions; updated `AppState` to expose `pomodoroCurrentMode` and subscribe to `pomodoro.$currentMode` alongside the existing `mode` stream.

### Testing
- Attempted to build with `xcodebuild -project macos/Pomodoro/Pomodoro.xcodeproj -scheme Pomodoro -configuration Debug build`, but the command failed because `xcodebuild` is not available in the environment (build could not be validated here).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b4a133dd88323b6d3a8b6c5321aeb)