### PR TITLE
Add PomodoroMode enum

### DIFF
--- a/macos/PomodoroApp/PomodoroMode.swift
+++ b/macos/PomodoroApp/PomodoroMode.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+enum PomodoroMode {
+    case idle
+    case work
+    case break
+    case longBreak
+}


### PR DESCRIPTION
### Motivation
- Introduce a simple type to represent the timer state across the app by adding a `PomodoroMode` enum.

### Description
- Added `macos/PomodoroApp/PomodoroMode.swift` which defines `enum PomodoroMode` with cases `idle`, `work`, `break`, and `longBreak`, and contains no logic, UI, or AppKit imports.

### Testing
- No automated tests or builds were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b4da9a08483238a73622362b55803)