### PR TITLE
Add currentMode to AppState

### DIFF
--- a/macos/PomodoroApp/AppState.swift
+++ b/macos/PomodoroApp/AppState.swift
@@ -1,5 +1,7 @@
 import SwiftUI
 
 final class AppState: ObservableObject {
+    @Published var currentMode: PomodoroMode = .idle
+
     init() {}
 }


### PR DESCRIPTION
### Motivation
- Expose the current Pomodoro mode from `AppState` so observers (menu bar, UI, and other consumers) can react to mode changes centrally.

### Description
- Add `@Published var currentMode: PomodoroMode = .idle` to `macos/PomodoroApp/AppState.swift` to publish the current mode.

### Testing
- Attempted `xcodebuild -project macos/Pomodoro/Pomodoro.xcodeproj -list` but `xcodebuild` is not available in this environment, so no automated build/tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b54d760908323bad690b365a61f1e)