### PR TITLE
Unify timer state handling

### DIFF
--- a/macos/Pomodoro/Pomodoro/AppState.swift
+++ b/macos/Pomodoro/Pomodoro/AppState.swift
@@ -108,10 +108,13 @@ final class AppState: ObservableObject {
     }
 
     func togglePomodoroPause() {
-        if pomodoro.state.isRunning {
+        switch pomodoro.state {
+        case .running, .breakRunning:
             pomodoro.pause()
-        } else if pomodoro.state.isPaused {
+        case .paused, .breakPaused:
             pomodoro.resume()
+        case .idle:
+            break
         }
     }
 
@@ -132,10 +135,13 @@ final class AppState: ObservableObject {
     }
 
     func toggleCountdownPause() {
-        if countdown.state.isRunning {
+        switch countdown.state {
+        case .running:
             countdown.pause()
-        } else if countdown.state.isPaused {
+        case .paused:
             countdown.resume()
+        case .idle, .breakRunning, .breakPaused:
+            break
         }
     }
 

--- a/macos/Pomodoro/Pomodoro/CountdownTimerEngine.swift
+++ b/macos/Pomodoro/Pomodoro/CountdownTimerEngine.swift
@@ -9,16 +9,7 @@ import Combine
 import Foundation
 
 final class CountdownTimerEngine: ObservableObject {
-    enum State: String {
-        case idle
-        case running
-        case paused
-
-        var isRunning: Bool { self == .running }
-        var isPaused: Bool { self == .paused }
-    }
-
-    @Published private(set) var state: State = .idle
+    @Published private(set) var state: TimerState = .idle
     @Published private(set) var remainingSeconds: Int
 
     private let duration: Int
@@ -37,15 +28,23 @@ final class CountdownTimerEngine: ObservableObject {
     }
 
     func pause() {
-        guard state == .running else { return }
-        state = .paused
-        stopTimer()
+        switch state {
+        case .running:
+            state = .paused
+            stopTimer()
+        case .idle, .paused, .breakRunning, .breakPaused:
+            return
+        }
     }
 
     func resume() {
-        guard state == .paused else { return }
-        state = .running
-        startTimer()
+        switch state {
+        case .paused:
+            state = .running
+            startTimer()
+        case .idle, .running, .breakRunning, .breakPaused:
+            return
+        }
     }
 
     func reset() {

--- a/macos/Pomodoro/Pomodoro/MainWindowView.swift
+++ b/macos/Pomodoro/Pomodoro/MainWindowView.swift
@@ -76,7 +76,7 @@ struct MainWindowView: View {
         return String(format: "%02d:%02d", minutes, remaining)
     }
 
-    private func labelForPomodoroState(_ state: PomodoroTimerEngine.State) -> String {
+    private func labelForPomodoroState(_ state: TimerState) -> String {
         switch state {
         case .idle:
             return "Idle"

--- a/macos/Pomodoro/Pomodoro/MenuBarController.swift
+++ b/macos/Pomodoro/Pomodoro/MenuBarController.swift
@@ -114,16 +114,19 @@ final class MenuBarController: NSObject, NSMenuDelegate {
     }
 
     private func currentMenuMode() -> MenuMode {
-        if appState.pomodoro.state == .running || appState.pomodoro.state == .paused {
+        switch appState.pomodoro.state {
+        case .running, .paused:
             return .pomodoro
-        }
-        if appState.pomodoro.state == .breakRunning || appState.pomodoro.state == .breakPaused {
+        case .breakRunning, .breakPaused:
             return .breakTime
+        case .idle:
+            switch appState.countdown.state {
+            case .running, .paused:
+                return .countdown
+            case .idle, .breakRunning, .breakPaused:
+                return .idle
+            }
         }
-        if appState.countdown.state != .idle {
-            return .countdown
-        }
-        return .idle
     }
 
     private func rebuildMenu() {
@@ -190,7 +193,12 @@ final class MenuBarController: NSObject, NSMenuDelegate {
     }
 
     private func pomodoroPauseTitle() -> String {
-        appState.pomodoro.state.isPaused ? "▶ Resume" : "⏸ Pause"
+        switch appState.pomodoro.state {
+        case .paused, .breakPaused:
+            return "▶ Resume"
+        case .running, .breakRunning, .idle:
+            return "⏸ Pause"
+        }
     }
 
     private func breakMenuTitle() -> String {
@@ -206,7 +214,12 @@ final class MenuBarController: NSObject, NSMenuDelegate {
     }
 
     private func countdownPauseTitle() -> String {
-        appState.countdown.state.isPaused ? "▶ Resume" : "⏸ Pause"
+        switch appState.countdown.state {
+        case .paused:
+            return "▶ Resume"
+        case .running, .idle, .breakRunning, .breakPaused:
+            return "⏸ Pause"
+        }
     }
 
     @objc private func startPomodoro() {

--- a/macos/Pomodoro/Pomodoro/TimerState.swift
+++ b/macos/Pomodoro/Pomodoro/TimerState.swift
@@ -1,0 +1,16 @@
+//
+//  TimerState.swift
+//  Pomodoro
+//
+//  Created by Zhengyang Hu on 1/15/26.
+//
+
+import Foundation
+
+enum TimerState: String {
+    case idle
+    case running
+    case paused
+    case breakRunning
+    case breakPaused
+}


### PR DESCRIPTION
### Motivation
- Centralize timer lifecycle into a single explicit enum so both Pomodoro and Countdown use the same state model (`idle`, `running`, `paused`, `breakRunning`, `breakPaused`).
- Replace boolean-like helpers with explicit switch-based transitions to make state flows clearer and safer.
- Prepare a small, incremental refactor to reduce duplicated state logic while preserving existing UI and behaviors.

### Description
- Added a shared `TimerState` enum in `macos/Pomodoro/Pomodoro/TimerState.swift` and switched both engines to publish `state: TimerState` instead of local enums. 
- Refactored `PomodoroTimerEngine` (`PomodoroTimerEngine.swift`) to use switch-based transitions for `start`, `pause`, `resume`, `skipBreak`, `startBreak`, and completion handling, and to update `currentMode` via a switch on `TimerState`.
- Updated `CountdownTimerEngine` (`CountdownTimerEngine.swift`) to use `TimerState` and switch-based `pause`/`resume` handling. 
- Updated app wiring to match the unified state: `AppState.togglePomodoroPause` and `AppState.toggleCountdownPause` use switches over `TimerState`, menu logic in `MenuBarController` now derives menu mode and titles from `TimerState`, and `MainWindowView` now formats the Pomodoro state using `TimerState`.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b5ac36a0c8323a1574b8563c6aa86)