### PR TITLE
Disable invalid timer controls and bump macOS version to 1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The 0.5.x branch introduces a new glass-panel layout system with separate tiles 
 ## Version status
 
 Current Version: <br>
-🧪 0.7.0 Beta
+✅ 1.0.0
 
 Update history: see history_versions/ for archived notes.
 

--- a/macos/Pomodoro/Pomodoro.xcodeproj/project.pbxproj
+++ b/macos/Pomodoro/Pomodoro.xcodeproj/project.pbxproj
@@ -335,7 +335,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.pomodoro.Pomodoro;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -365,7 +365,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.pomodoro.Pomodoro;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;

--- a/macos/Pomodoro/Pomodoro/MainWindowView.swift
+++ b/macos/Pomodoro/Pomodoro/MainWindowView.swift
@@ -25,18 +25,22 @@ struct MainWindowView: View {
                 Button("Start") {
                     appState.pomodoro.start()
                 }
+                .disabled(!pomodoroActions(for: appState.pomodoro.state).canStart)
                 Button("Pause") {
                     appState.pomodoro.pause()
                 }
+                .disabled(!pomodoroActions(for: appState.pomodoro.state).canPause)
                 Button("Resume") {
                     appState.pomodoro.resume()
                 }
+                .disabled(!pomodoroActions(for: appState.pomodoro.state).canResume)
                 Button("Reset") {
                     appState.pomodoro.reset()
                 }
                 Button("Skip Break") {
                     appState.pomodoro.skipBreak()
                 }
+                .disabled(!pomodoroActions(for: appState.pomodoro.state).canSkipBreak)
             }
 
             Divider()
@@ -54,12 +58,15 @@ struct MainWindowView: View {
                 Button("Start") {
                     appState.countdown.start()
                 }
+                .disabled(!countdownActions(for: appState.countdown.state).canStart)
                 Button("Pause") {
                     appState.countdown.pause()
                 }
+                .disabled(!countdownActions(for: appState.countdown.state).canPause)
                 Button("Resume") {
                     appState.countdown.resume()
                 }
+                .disabled(!countdownActions(for: appState.countdown.state).canResume)
                 Button("Reset") {
                     appState.countdown.reset()
                 }
@@ -99,6 +106,72 @@ struct MainWindowView: View {
             return "Break"
         case .longBreak:
             return "Long Break"
+        }
+    }
+
+    private struct PomodoroActionAvailability {
+        let canStart: Bool
+        let canPause: Bool
+        let canResume: Bool
+        let canSkipBreak: Bool
+    }
+
+    private struct CountdownActionAvailability {
+        let canStart: Bool
+        let canPause: Bool
+        let canResume: Bool
+    }
+
+    private func pomodoroActions(for state: TimerState) -> PomodoroActionAvailability {
+        switch state {
+        case .idle:
+            return PomodoroActionAvailability(
+                canStart: true,
+                canPause: false,
+                canResume: false,
+                canSkipBreak: false
+            )
+        case .running:
+            return PomodoroActionAvailability(
+                canStart: false,
+                canPause: true,
+                canResume: false,
+                canSkipBreak: false
+            )
+        case .paused:
+            return PomodoroActionAvailability(
+                canStart: false,
+                canPause: false,
+                canResume: true,
+                canSkipBreak: false
+            )
+        case .breakRunning:
+            return PomodoroActionAvailability(
+                canStart: false,
+                canPause: true,
+                canResume: false,
+                canSkipBreak: true
+            )
+        case .breakPaused:
+            return PomodoroActionAvailability(
+                canStart: false,
+                canPause: false,
+                canResume: true,
+                canSkipBreak: true
+            )
+        }
+    }
+
+    private func countdownActions(for state: TimerState) -> CountdownActionAvailability {
+        switch state {
+        case .idle:
+            return CountdownActionAvailability(canStart: true, canPause: false, canResume: false)
+        case .running:
+            return CountdownActionAvailability(canStart: false, canPause: true, canResume: false)
+        case .paused:
+            return CountdownActionAvailability(canStart: false, canPause: false, canResume: true)
+        case .breakRunning, .breakPaused:
+            return CountdownActionAvailability(canStart: false, canPause: false, canResume: false)
         }
     }
 }


### PR DESCRIPTION
### Motivation
- Ensure UI buttons are only enabled for actions valid for the current timer state, deriving availability purely from `TimerState` to avoid duplicated logic.
- Ship a formal native release bump by updating the macOS marketing version to `1.0.0` and update the README version badge.

### Description
- Added explicit action-availability types and lookup helpers in `MainWindowView.swift` (`PomodoroActionAvailability`, `CountdownActionAvailability`, `pomodoroActions(for:)`, `countdownActions(for:)`) to derive button enablement from `TimerState`.
- Disabled Pomodoro buttons (`Start`, `Pause`, `Resume`, `Skip Break`) using `.disabled(...)` with the new availability logic so `Pause` is disabled when idle, `Resume` is disabled when running, and `Skip Break` only enabled during break states.
- Disabled countdown buttons (`Start`, `Pause`, `Resume`) similarly so actions follow the countdown `TimerState`.
- Updated Xcode project `MARKETING_VERSION` to `1.0.0` in `project.pbxproj` and changed the README version indicator to `1.0.0`.

### Testing
- No automated tests were executed as part of this change (none requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b5bb184e88323ac0a937922cabdb6)