### PR TITLE
Include TimerState.swift in Pomodoro target (fix missing TimerState)

### DIFF
--- a/macos/Pomodoro/Pomodoro.xcodeproj/project.pbxproj
+++ b/macos/Pomodoro/Pomodoro.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		7C360D572F191F17007313D3 /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C360D502F191F17007313D3 /* AppState.swift */; };
 		7C360D6D2F191F17007313D3 /* DurationConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C360D6E2F191F17007313D3 /* DurationConfig.swift */; };
+		7C360D6F2F191F17007313D3 /* TimerState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C360D702F191F17007313D3 /* TimerState.swift */; };
 		7C360D582F191F17007313D3 /* CountdownTimerEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C360D512F191F17007313D3 /* CountdownTimerEngine.swift */; };
 		7C360D592F191F17007313D3 /* PomodoroTimerEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C360D522F191F17007313D3 /* PomodoroTimerEngine.swift */; };
 		7C360D5A2F191F17007313D3 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C360D532F191F17007313D3 /* ContentView.swift */; };
@@ -23,6 +24,7 @@
 		7C360D382F191F17007313D3 /* Pomodoro.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Pomodoro.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		7C360D502F191F17007313D3 /* AppState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppState.swift; sourceTree = "<group>"; };
 		7C360D6E2F191F17007313D3 /* DurationConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DurationConfig.swift; sourceTree = "<group>"; };
+		7C360D702F191F17007313D3 /* TimerState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerState.swift; sourceTree = "<group>"; };
 		7C360D512F191F17007313D3 /* CountdownTimerEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CountdownTimerEngine.swift; sourceTree = "<group>"; };
 		7C360D522F191F17007313D3 /* PomodoroTimerEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PomodoroTimerEngine.swift; sourceTree = "<group>"; };
 		7C360D532F191F17007313D3 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -87,6 +89,7 @@
 			children = (
 				7C360D502F191F17007313D3 /* AppState.swift */,
 				7C360D6E2F191F17007313D3 /* DurationConfig.swift */,
+				7C360D702F191F17007313D3 /* TimerState.swift */,
 			);
 			name = State;
 			sourceTree = "<group>";
@@ -196,6 +199,7 @@
 				7C360D6A2F191F17007313D3 /* MenuBarController.swift in Sources */,
 				7C360D572F191F17007313D3 /* AppState.swift in Sources */,
 				7C360D6D2F191F17007313D3 /* DurationConfig.swift in Sources */,
+				7C360D6F2F191F17007313D3 /* TimerState.swift in Sources */,
 				7C360D582F191F17007313D3 /* CountdownTimerEngine.swift in Sources */,
 				7C360D592F191F17007313D3 /* PomodoroTimerEngine.swift in Sources */,
 			);


### PR DESCRIPTION
### Motivation
- The compiler could not find the shared `TimerState` type because the model file was not included in the app target, so both timer engines lost visibility to the single source of truth.

### Description
- Add `macos/Pomodoro/Pomodoro/TimerState.swift` to the Xcode project State group and the Pomodoro target Sources build phase so the enum is compiled into the app module and shared by `PomodoroTimerEngine` and `CountdownTimerEngine`.

```swift
import Foundation

enum TimerState: String {
    case idle
    case running
    case paused
    case breakRunning
    case breakPaused
}
```

- The file should live at `macos/Pomodoro/Pomodoro/TimerState.swift` (group: State) and is now referenced in `macos/Pomodoro/Pomodoro.xcodeproj/project.pbxproj` under the target sources.
- The enum uses the default `internal` access (no explicit modifier) which is correct for a single-target app; change to `public` only if the type later needs to be exposed from a separate framework/module.

### Testing
- No automated tests were executed as part of this change; the update is limited to adding the model file to the Pomodoro target sources and should resolve the compile-time "Cannot find type 'TimerState' in scope" error in Xcode.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b5efd1f4883239ad5616e31c5bb34)