### PR TITLE
Add duration steppers to MainWindowView and bump version to 1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The 0.5.x branch introduces a new glass-panel layout system with separate tiles 
 ## Version status
 
 Current Version: <br>
-🧪 0.7.0 Beta → ✅ 1.0.0
+✅ 1.0.0
 
 Update history: see history_versions/ for archived notes.
 

--- a/macos/Pomodoro/Pomodoro/MainWindowView.swift
+++ b/macos/Pomodoro/Pomodoro/MainWindowView.swift
@@ -43,6 +43,20 @@ struct MainWindowView: View {
                 .disabled(!pomodoroActions(for: appState.pomodoro.state).canSkipBreak)
             }
 
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Durations")
+                    .font(.headline)
+                Stepper(value: workMinutesBinding, in: 1...120, step: 1) {
+                    Text("Work: \(workMinutesValue) min")
+                }
+                Stepper(value: shortBreakMinutesBinding, in: 1...60, step: 1) {
+                    Text("Short Break: \(shortBreakMinutesValue) min")
+                }
+                Stepper(value: longBreakMinutesBinding, in: 1...90, step: 1) {
+                    Text("Long Break: \(longBreakMinutesValue) min")
+                }
+            }
+
             Divider()
 
             VStack(alignment: .leading, spacing: 8) {
@@ -173,6 +187,57 @@ struct MainWindowView: View {
         case .breakRunning, .breakPaused:
             return CountdownActionAvailability(canStart: false, canPause: false, canResume: false)
         }
+    }
+
+    private var workMinutesValue: Int {
+        max(1, appState.durationConfig.workDuration / 60)
+    }
+
+    private var shortBreakMinutesValue: Int {
+        max(1, appState.durationConfig.shortBreakDuration / 60)
+    }
+
+    private var longBreakMinutesValue: Int {
+        max(1, appState.durationConfig.longBreakDuration / 60)
+    }
+
+    private var workMinutesBinding: Binding<Int> {
+        Binding(
+            get: { workMinutesValue },
+            set: { updateDurationConfig(workMinutes: $0) }
+        )
+    }
+
+    private var shortBreakMinutesBinding: Binding<Int> {
+        Binding(
+            get: { shortBreakMinutesValue },
+            set: { updateDurationConfig(shortBreakMinutes: $0) }
+        )
+    }
+
+    private var longBreakMinutesBinding: Binding<Int> {
+        Binding(
+            get: { longBreakMinutesValue },
+            set: { updateDurationConfig(longBreakMinutes: $0) }
+        )
+    }
+
+    private func updateDurationConfig(
+        workMinutes: Int? = nil,
+        shortBreakMinutes: Int? = nil,
+        longBreakMinutes: Int? = nil
+    ) {
+        let currentConfig = appState.durationConfig
+        let updatedWorkMinutes = max(1, workMinutes ?? currentConfig.workDuration / 60)
+        let updatedShortBreakMinutes = max(1, shortBreakMinutes ?? currentConfig.shortBreakDuration / 60)
+        let updatedLongBreakMinutes = max(1, longBreakMinutes ?? currentConfig.longBreakDuration / 60)
+
+        appState.durationConfig = DurationConfig(
+            workDuration: updatedWorkMinutes * 60,
+            shortBreakDuration: updatedShortBreakMinutes * 60,
+            longBreakDuration: updatedLongBreakMinutes * 60,
+            longBreakInterval: currentConfig.longBreakInterval
+        )
     }
 }
 


### PR DESCRIPTION
### Motivation
- Expose a simple, temporary UI to let users edit work and break durations in-app without changing architecture.
- Ensure duration changes immediately affect upcoming Pomodoro sessions by updating the shared `durationConfig` source of truth.
- Mark the native app milestone by updating the README version status to `1.0.0`.

### Description
- Added a "Durations" section in `MainWindowView` with three `Stepper` controls for Work, Short Break, and Long Break minutes, constrained to reasonable minute ranges.
- Wired the steppers to derived `Binding<Int>`s that call `updateDurationConfig(...)`, which writes a new `DurationConfig` to `appState.durationConfig` while preserving `longBreakInterval`.
- The `AppState` publishes `durationConfig` and already forwards configuration to the `PomodoroTimerEngine`, so changes take effect for the next session without altering existing behavior.
- Updated `README.md` version status from the beta line to `✅ 1.0.0`.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b6051d23883238e1d5ab1bbaad3f7)