### PR TITLE
Use DurationConfig for countdown timer

### DIFF
--- a/macos/Pomodoro/Pomodoro/AppState.swift
+++ b/macos/Pomodoro/Pomodoro/AppState.swift
@@ -80,6 +80,7 @@ final class AppState: ObservableObject {
         pomodoro.updateConfiguration(
             durationConfig: durationConfig
         )
+        countdown.updateConfiguration(durationConfig: durationConfig)
     }
 
     func startPomodoro() {

--- a/macos/Pomodoro/Pomodoro/CountdownTimerEngine.swift
+++ b/macos/Pomodoro/Pomodoro/CountdownTimerEngine.swift
@@ -12,12 +12,26 @@ final class CountdownTimerEngine: ObservableObject {
     @Published private(set) var state: TimerState = .idle
     @Published private(set) var remainingSeconds: Int
 
-    private let duration: Int
+    private var durationConfig: DurationConfig
+    private let durationProvider: (DurationConfig) -> Int
     private var timer: Timer?
 
-    init(duration: Int = 10 * 60) {
-        self.duration = duration
-        self.remainingSeconds = duration
+    init(
+        durationConfig: DurationConfig = .standard,
+        durationProvider: @escaping (DurationConfig) -> Int = { $0.shortBreakDuration * 2 }
+    ) {
+        self.durationConfig = durationConfig
+        self.durationProvider = durationProvider
+        let resolvedDuration = durationProvider(durationConfig)
+        self.remainingSeconds = resolvedDuration
+    }
+
+    func updateConfiguration(durationConfig: DurationConfig) {
+        self.durationConfig = durationConfig
+
+        if state == .idle {
+            remainingSeconds = duration
+        }
     }
 
     func start() {
@@ -82,5 +96,9 @@ final class CountdownTimerEngine: ObservableObject {
         stopTimer()
         state = .idle
         remainingSeconds = duration
+    }
+
+    private var duration: Int {
+        durationProvider(durationConfig)
     }
 }


### PR DESCRIPTION
### Motivation
- Ensure all timer engines read durations from the shared `DurationConfig` model as part of the v0.7.0→1.0.0 evolution.
- Keep configuration explicit and allow the countdown timer to respond to changes in the global durations.

### Description
- Updated `CountdownTimerEngine` to accept a `DurationConfig` and a `durationProvider` closure and to derive its runtime duration from the provided config.
- Added `updateConfiguration(durationConfig:)` to `CountdownTimerEngine` so the idle remaining seconds are refreshed when the shared config changes.
- Added a computed `duration` property that resolves the effective duration via the `durationProvider` and replaced hardcoded duration usage with it.
- Propagated `durationConfig` updates from `AppState` to the `countdown` engine alongside the existing propagation to the pomodoro engine.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b60f481e48323aba58bca559e3a0d)