### PR TITLE
Persist DurationConfig to UserDefaults and load on launch

### DIFF
--- a/macos/Pomodoro/Pomodoro/AppState.swift
+++ b/macos/Pomodoro/Pomodoro/AppState.swift
@@ -13,24 +13,30 @@ final class AppState: ObservableObject {
     let countdown: CountdownTimerEngine
 
     @Published var durationConfig: DurationConfig {
-        didSet { updatePomodoroConfiguration() }
+        didSet {
+            updatePomodoroConfiguration()
+            durationConfig.save(to: userDefaults)
+        }
     }
 
     @Published private(set) var pomodoroMode: PomodoroTimerEngine.Mode
     @Published private(set) var pomodoroCurrentMode: PomodoroTimerEngine.CurrentMode
 
     private var cancellables: Set<AnyCancellable> = []
+    private let userDefaults: UserDefaults
 
     init(
         pomodoro: PomodoroTimerEngine,
         countdown: CountdownTimerEngine,
-        durationConfig: DurationConfig
+        durationConfig: DurationConfig,
+        userDefaults: UserDefaults = .standard
     ) {
         self.pomodoro = pomodoro
         self.countdown = countdown
         self.durationConfig = durationConfig
         self.pomodoroMode = pomodoro.mode
         self.pomodoroCurrentMode = pomodoro.currentMode
+        self.userDefaults = userDefaults
 
         pomodoro.objectWillChange
             .sink { [weak self] _ in
@@ -63,17 +69,23 @@ final class AppState: ObservableObject {
 
     convenience init(
         pomodoro: PomodoroTimerEngine = PomodoroTimerEngine(),
-        countdown: CountdownTimerEngine = CountdownTimerEngine()
+        countdown: CountdownTimerEngine = CountdownTimerEngine(),
+        userDefaults: UserDefaults = .standard
     ) {
+        let storedConfig = DurationConfig.load(from: userDefaults)
         self.init(
             pomodoro: pomodoro,
             countdown: countdown,
-            durationConfig: .standard
+            durationConfig: storedConfig,
+            userDefaults: userDefaults
         )
     }
 
     convenience init() {
-        self.init(pomodoro: PomodoroTimerEngine(), countdown: CountdownTimerEngine())
+        self.init(
+            pomodoro: PomodoroTimerEngine(),
+            countdown: CountdownTimerEngine()
+        )
     }
 
     private func updatePomodoroConfiguration() {

--- a/macos/Pomodoro/Pomodoro/DurationConfig.swift
+++ b/macos/Pomodoro/Pomodoro/DurationConfig.swift
@@ -8,6 +8,13 @@
 import Foundation
 
 struct DurationConfig: Equatable {
+    private enum DefaultsKey {
+        static let workDuration = "durationConfig.workDuration"
+        static let shortBreakDuration = "durationConfig.shortBreakDuration"
+        static let longBreakDuration = "durationConfig.longBreakDuration"
+        static let longBreakInterval = "durationConfig.longBreakInterval"
+    }
+
     let workDuration: Int
     let shortBreakDuration: Int
     let longBreakDuration: Int
@@ -31,4 +38,34 @@ struct DurationConfig: Equatable {
         longBreakDuration: 15 * 60,
         longBreakInterval: 4
     )
+
+    static func load(from defaults: UserDefaults) -> DurationConfig {
+        let workDurationValue = defaults.object(forKey: DefaultsKey.workDuration) as? NSNumber
+        let shortBreakDurationValue = defaults.object(forKey: DefaultsKey.shortBreakDuration) as? NSNumber
+        let longBreakDurationValue = defaults.object(forKey: DefaultsKey.longBreakDuration) as? NSNumber
+        let longBreakIntervalValue = defaults.object(forKey: DefaultsKey.longBreakInterval) as? NSNumber
+
+        guard
+            let workDuration = workDurationValue?.intValue,
+            let shortBreakDuration = shortBreakDurationValue?.intValue,
+            let longBreakDuration = longBreakDurationValue?.intValue,
+            let longBreakInterval = longBreakIntervalValue?.intValue
+        else {
+            return .standard
+        }
+
+        return DurationConfig(
+            workDuration: workDuration,
+            shortBreakDuration: shortBreakDuration,
+            longBreakDuration: longBreakDuration,
+            longBreakInterval: longBreakInterval
+        )
+    }
+
+    func save(to defaults: UserDefaults) {
+        defaults.set(workDuration, forKey: DefaultsKey.workDuration)
+        defaults.set(shortBreakDuration, forKey: DefaultsKey.shortBreakDuration)
+        defaults.set(longBreakDuration, forKey: DefaultsKey.longBreakDuration)
+        defaults.set(longBreakInterval, forKey: DefaultsKey.longBreakInterval)
+    }
 }


### PR DESCRIPTION
### Motivation
- Persist user-adjusted Pomodoro and break durations across launches so configuration survives app restarts.
- Provide safe fallback to the app's standard durations when stored values are missing or invalid.

### Description
- Add `DefaultsKey` constants and `load(from:)` / `save(to:)` helpers on `DurationConfig` to read/write values from `UserDefaults` and return `.standard` when entries are missing or invalid.
- Make `DurationConfig.load` tolerant of stored numeric types by reading `NSNumber` and extracting `intValue`.
- Extend `AppState` to accept a `UserDefaults` instance, load the stored `DurationConfig` in the convenience initializer, and persist `durationConfig` on every change in `didSet`.
- Ensure existing behavior is preserved by using `.standard` as a safe default when no stored values are present.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b62a5443c8323b015f9fd8d3cee57)