### PR TITLE
Remove default args from AppState convenience initializers to fix linker errors

### DIFF
--- a/macos/Pomodoro/Pomodoro/AppState.swift
+++ b/macos/Pomodoro/Pomodoro/AppState.swift
@@ -68,9 +68,9 @@ final class AppState: ObservableObject {
     }
 
     convenience init(
-        pomodoro: PomodoroTimerEngine = PomodoroTimerEngine(),
-        countdown: CountdownTimerEngine = CountdownTimerEngine(),
-        userDefaults: UserDefaults = .standard
+        pomodoro: PomodoroTimerEngine,
+        countdown: CountdownTimerEngine,
+        userDefaults: UserDefaults
     ) {
         let storedConfig = DurationConfig.load(from: userDefaults)
         self.init(
@@ -78,6 +78,17 @@ final class AppState: ObservableObject {
             countdown: countdown,
             durationConfig: storedConfig,
             userDefaults: userDefaults
+        )
+    }
+
+    convenience init(
+        pomodoro: PomodoroTimerEngine,
+        countdown: CountdownTimerEngine
+    ) {
+        self.init(
+            pomodoro: pomodoro,
+            countdown: countdown,
+            userDefaults: .standard
         )
     }
 


### PR DESCRIPTION
### Motivation
- The linker failed with undefined symbols for `AppState` initializers because default-argument thunks were expected but not emitted/linked across the build boundary for the convenience initializer that used inline default parameter values.
- Default values on the convenience initializer caused the compiler to synthesize default-argument helper symbols which led to missing symbols at link time when callers resolved the convenience initializer using omitted arguments.

### Description
- Removed default parameter values from the `convenience init` in `macos/Pomodoro/Pomodoro/AppState.swift` so the initializer signature no longer relies on default-argument thunks. 
- Added explicit overloaded convenience initializers that forward to the designated initializer: one taking `(pomodoro: PomodoroTimerEngine, countdown: CountdownTimerEngine, userDefaults: UserDefaults)` and one taking `(pomodoro: PomodoroTimerEngine, countdown: CountdownTimerEngine)` which supplies `.standard` for `userDefaults`, and preserved the no-argument convenience `init()` that constructs default engines. 
- Kept the designated `init(pomodoro:countdown:durationConfig:userDefaults:)` as the single implementation point so symbols are concrete and callers bind to explicit overloads instead of default-argument helpers.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b64f5bfb08323814dec472ac31e26)