### PR TITLE
Add preset selection for Pomodoro durations

### DIFF
--- a/macos/Pomodoro/Pomodoro/AppState.swift
+++ b/macos/Pomodoro/Pomodoro/AppState.swift
@@ -19,6 +19,8 @@ final class AppState: ObservableObject {
         }
     }
 
+    @Published var presetSelection: PresetSelection
+
     @Published private(set) var pomodoroMode: PomodoroTimerEngine.Mode
     @Published private(set) var pomodoroCurrentMode: PomodoroTimerEngine.CurrentMode
 
@@ -35,6 +37,7 @@ final class AppState: ObservableObject {
         self.pomodoro = pomodoro
         self.countdown = countdown
         self.durationConfig = durationConfig
+        self.presetSelection = PresetSelection.selection(for: durationConfig)
         self.pomodoroMode = pomodoro.mode
         self.pomodoroCurrentMode = pomodoro.currentMode
         self.userDefaults = userDefaults
@@ -108,6 +111,25 @@ final class AppState: ObservableObject {
             durationConfig: durationConfig
         )
         countdown.updateConfiguration(durationConfig: durationConfig)
+    }
+
+    func applyPresetSelection(_ selection: PresetSelection) {
+        switch selection {
+        case .preset(let preset):
+            selectPreset(preset)
+        case .custom:
+            presetSelection = .custom
+        }
+    }
+
+    func selectPreset(_ preset: Preset) {
+        presetSelection = .preset(preset)
+        durationConfig = preset.durationConfig
+    }
+
+    func applyCustomDurationConfig(_ config: DurationConfig) {
+        presetSelection = .custom
+        durationConfig = config
     }
 
     func startPomodoro() {

--- a/macos/Pomodoro/Pomodoro/MainWindowView.swift
+++ b/macos/Pomodoro/Pomodoro/MainWindowView.swift
@@ -21,6 +21,20 @@ struct MainWindowView: View {
                     .font(.subheadline)
             }
 
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Preset")
+                    .font(.headline)
+                Picker("Preset", selection: presetSelectionBinding) {
+                    ForEach(Preset.builtIn) { preset in
+                        Text(preset.name)
+                            .tag(PresetSelection.preset(preset))
+                    }
+                    Text("Custom")
+                        .tag(PresetSelection.custom)
+                }
+                .pickerStyle(.segmented)
+            }
+
             HStack(spacing: 12) {
                 Button("Start") {
                     appState.pomodoro.start()
@@ -232,11 +246,18 @@ struct MainWindowView: View {
         let updatedShortBreakMinutes = max(1, shortBreakMinutes ?? currentConfig.shortBreakDuration / 60)
         let updatedLongBreakMinutes = max(1, longBreakMinutes ?? currentConfig.longBreakDuration / 60)
 
-        appState.durationConfig = DurationConfig(
+        appState.applyCustomDurationConfig(DurationConfig(
             workDuration: updatedWorkMinutes * 60,
             shortBreakDuration: updatedShortBreakMinutes * 60,
             longBreakDuration: updatedLongBreakMinutes * 60,
             longBreakInterval: currentConfig.longBreakInterval
+        ))
+    }
+
+    private var presetSelectionBinding: Binding<PresetSelection> {
+        Binding(
+            get: { appState.presetSelection },
+            set: { appState.applyPresetSelection($0) }
         )
     }
 }

--- a/macos/Pomodoro/Pomodoro/Preset.swift
+++ b/macos/Pomodoro/Pomodoro/Preset.swift
@@ -1,0 +1,54 @@
+//
+//  Preset.swift
+//  Pomodoro
+//
+//  Created by OpenAI on 3/2/25.
+//
+
+import Foundation
+
+struct Preset: Identifiable, Hashable {
+    let id: String
+    let name: String
+    let durationConfig: DurationConfig
+
+    init(name: String, durationConfig: DurationConfig) {
+        self.id = name
+        self.name = name
+        self.durationConfig = durationConfig
+    }
+
+    static let builtIn: [Preset] = [
+        Preset(
+            name: "25 / 5",
+            durationConfig: DurationConfig(
+                workDuration: 25 * 60,
+                shortBreakDuration: 5 * 60,
+                longBreakDuration: 15 * 60,
+                longBreakInterval: 4
+            )
+        ),
+        Preset(
+            name: "50 / 10",
+            durationConfig: DurationConfig(
+                workDuration: 50 * 60,
+                shortBreakDuration: 10 * 60,
+                longBreakDuration: 30 * 60,
+                longBreakInterval: 4
+            )
+        ),
+        Preset(
+            name: "90 / 15",
+            durationConfig: DurationConfig(
+                workDuration: 90 * 60,
+                shortBreakDuration: 15 * 60,
+                longBreakDuration: 45 * 60,
+                longBreakInterval: 4
+            )
+        )
+    ]
+
+    static func matching(durationConfig: DurationConfig) -> Preset? {
+        builtIn.first { $0.durationConfig == durationConfig }
+    }
+}

--- a/macos/Pomodoro/Pomodoro/PresetSelection.swift
+++ b/macos/Pomodoro/Pomodoro/PresetSelection.swift
@@ -1,0 +1,21 @@
+//
+//  PresetSelection.swift
+//  Pomodoro
+//
+//  Created by OpenAI on 3/2/25.
+//
+
+import Foundation
+
+enum PresetSelection: Hashable {
+    case preset(Preset)
+    case custom
+
+    static func selection(for durationConfig: DurationConfig) -> PresetSelection {
+        if let preset = Preset.matching(durationConfig: durationConfig) {
+            return .preset(preset)
+        }
+
+        return .custom
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide quick, built-in duration presets for common Pomodoro configurations while preserving existing manual editing behavior. 
- Keep changes small and macOS-native by adding explicit preset state instead of boolean flags. 

### Description
- Add a `Preset` model with built-in presets (`25 / 5`, `50 / 10`, `90 / 15`) and a `matching` helper in `Preset.swift`. 
- Add a `PresetSelection` enum in `PresetSelection.swift` to represent either a selected preset or `custom`. 
- Track preset selection in `AppState` with a new `@Published var presetSelection` and initialize it from the current `DurationConfig`, and add `applyPresetSelection`, `selectPreset`, and `applyCustomDurationConfig` helpers in `AppState.swift`. 
- Add a segmented `Picker` UI in `MainWindowView.swift` bound to the preset selection, and make manual edits call `applyCustomDurationConfig(...)` so editing switches to `custom` without auto-starting timers. 

### Testing
- Automated tests: none executed. 
- Manual/compile testing: no automated build or unit tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b9a4066408323b2e83d4fb4f920c9)