### PR TITLE
Fix long break interval logic in PomodoroTimerEngine

### DIFF
--- a/macos/Pomodoro/Pomodoro/PomodoroTimerEngine.swift
+++ b/macos/Pomodoro/Pomodoro/PomodoroTimerEngine.swift
@@ -103,9 +103,6 @@ final class PomodoroTimerEngine: ObservableObject {
         stopTimer()
         state = .idle
         remainingSeconds = durationConfig.workDuration
-        if mode == .longBreak {
-            completedWorkSessions = 0
-        }
         mode = .work
         updateCurrentMode()
     }
@@ -153,9 +150,6 @@ final class PomodoroTimerEngine: ObservableObject {
             stopTimer()
             state = .idle
             remainingSeconds = durationConfig.workDuration
-            if mode == .longBreak {
-                completedWorkSessions = 0
-            }
             mode = .work
             updateCurrentMode()
         case .running, .paused:
@@ -170,14 +164,13 @@ final class PomodoroTimerEngine: ObservableObject {
         state = .breakRunning
         mode = isLongBreak ? .longBreak : .breakTime
         remainingSeconds = isLongBreak ? durationConfig.longBreakDuration : durationConfig.shortBreakDuration
-        if isLongBreak {
-            completedWorkSessions = 0
-        }
         updateCurrentMode()
     }
 
     private func isLongBreakDue() -> Bool {
-        completedWorkSessions >= durationConfig.longBreakInterval
+        // Choose a long break on exact interval boundaries without resetting the counter.
+        completedWorkSessions > 0
+            && completedWorkSessions % durationConfig.longBreakInterval == 0
     }
 
     private func updateCurrentMode() {


### PR DESCRIPTION
### Motivation
- Ensure long breaks are selected based on a configurable interval and that the completed-work counter is preserved across breaks and only reset by an explicit `reset()` to match intended Pomodoro semantics.

### Description
- Updated `PomodoroTimerEngine.swift` to stop resetting `completedWorkSessions` during break transitions and `skipBreak()`, and to increment `completedWorkSessions` only on completed work sessions; changed `isLongBreakDue()` to use `completedWorkSessions > 0 && completedWorkSessions % durationConfig.longBreakInterval == 0` and added a short comment explaining the decision.

### Testing
- No automated tests were run on this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b9cfd0dc083238a06161e3f4e9744)