### PR TITLE
Add notification preferences and reminder alerts

### DIFF
--- a/macos/Pomodoro/Pomodoro/MainWindowView.swift
+++ b/macos/Pomodoro/Pomodoro/MainWindowView.swift
@@ -95,6 +95,26 @@ struct MainWindowView: View {
                 }
             }
 
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Notifications")
+                    .font(.headline)
+                Picker("Notifications", selection: $appState.notificationPreference) {
+                    ForEach(NotificationPreference.allCases) { preference in
+                        Text(preference.title)
+                            .tag(preference)
+                    }
+                }
+                .pickerStyle(.segmented)
+
+                Picker("Reminder", selection: $appState.reminderPreference) {
+                    ForEach(ReminderPreference.allCases) { preference in
+                        Text(preference.title)
+                            .tag(preference)
+                    }
+                }
+                .pickerStyle(.segmented)
+            }
+
             Divider()
 
             VStack(alignment: .leading, spacing: 8) {

--- a/macos/Pomodoro/Pomodoro/NotificationPreference.swift
+++ b/macos/Pomodoro/Pomodoro/NotificationPreference.swift
@@ -1,0 +1,52 @@
+//
+//  NotificationPreference.swift
+//  Pomodoro
+//
+//  Created by OpenAI on 2025-02-01.
+//
+
+import Foundation
+
+enum NotificationPreference: String, CaseIterable, Identifiable {
+    case off
+    case silent
+    case sound
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .off:
+            return "Off"
+        case .silent:
+            return "Silent banner"
+        case .sound:
+            return "Banner + sound"
+        }
+    }
+}
+
+enum ReminderPreference: String, CaseIterable, Identifiable {
+    case off
+    case oneMinute
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .off:
+            return "Off"
+        case .oneMinute:
+            return "1 minute before"
+        }
+    }
+
+    var leadTimeSeconds: Int {
+        switch self {
+        case .off:
+            return 0
+        case .oneMinute:
+            return 60
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide users explicit control over notifications with three options: `Off`, `Silent banner`, and `Banner + sound` and an optional reminder before session end.  
- Persist the preferences and emit notifications for Pomodoro end, break end, and countdown end while respecting user settings and macOS permissions.  
- Keep changes small and incremental by wiring into the existing `AppState` observers and UI without altering core timer engines.

### Description
- Add `NotificationPreference` and `ReminderPreference` enums in `macos/Pomodoro/Pomodoro/NotificationPreference.swift` to represent persisted user choices and reminder lead time.  
- Add `@Published` properties `notificationPreference` and `reminderPreference` to `AppState`, persist them to `UserDefaults` via `DefaultsKey`, and request notification authorization only when needed.  
- Observe `pomodoro` and `countdown` state and remaining seconds in `AppState` and send notifications (and optional 1-minute reminders) via `UNUserNotificationCenter`, with sound only when `notificationPreference == .sound`.  
- Add notification and reminder pickers to the main UI in `MainWindowView` bound to `appState.notificationPreference` and `appState.reminderPreference` so users can change preferences from the main window, with reminders disabled by default.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696c5553b27883239f8f59206ceab0b8)