### PR TITLE
Add DailyStats model and wire daily tracking into AppState

### DIFF
--- a/macos/Pomodoro/Pomodoro/DailyStats.swift
+++ b/macos/Pomodoro/Pomodoro/DailyStats.swift
@@ -1,0 +1,49 @@
+//
+//  DailyStats.swift
+//  Pomodoro
+//
+//  Created by Zhengyang Hu on 1/15/26.
+//
+
+import Foundation
+
+struct DailyStats: Equatable {
+    private(set) var dayStart: Date
+    private(set) var totalFocusSeconds: Int
+    private(set) var totalBreakSeconds: Int
+    private(set) var completedSessions: Int
+
+    init(date: Date = Date(), calendar: Calendar = .current) {
+        let startOfDay = calendar.startOfDay(for: date)
+        self.dayStart = startOfDay
+        self.totalFocusSeconds = 0
+        self.totalBreakSeconds = 0
+        self.completedSessions = 0
+    }
+
+    mutating func reset(for date: Date = Date(), calendar: Calendar = .current) {
+        dayStart = calendar.startOfDay(for: date)
+        totalFocusSeconds = 0
+        totalBreakSeconds = 0
+        completedSessions = 0
+    }
+
+    mutating func ensureCurrentDay(_ date: Date = Date(), calendar: Calendar = .current) {
+        let startOfDay = calendar.startOfDay(for: date)
+        guard startOfDay != dayStart else { return }
+        reset(for: date, calendar: calendar)
+    }
+
+    mutating func logFocusSession(durationSeconds: Int, date: Date = Date(), calendar: Calendar = .current) {
+        guard durationSeconds > 0 else { return }
+        ensureCurrentDay(date, calendar: calendar)
+        totalFocusSeconds += durationSeconds
+        completedSessions += 1
+    }
+
+    mutating func logBreakSession(durationSeconds: Int, date: Date = Date(), calendar: Calendar = .current) {
+        guard durationSeconds > 0 else { return }
+        ensureCurrentDay(date, calendar: calendar)
+        totalBreakSeconds += durationSeconds
+    }
+}


### PR DESCRIPTION
### Motivation

- Provide per-day metrics for the Pomodoro experience: total focus time, total break time, and completed sessions.  
- Ensure stats are scoped to the calendar day and only increment when a session truly completes (not on pause or reset).

### Description

- Add a new `DailyStats` value type (`macos/Pomodoro/Pomodoro/DailyStats.swift`) that stores `dayStart`, `totalFocusSeconds`, `totalBreakSeconds`, and `completedSessions`, with `ensureCurrentDay` and reset behavior.  
- Expose `dailyStats` on `AppState` and add transient state `currentFocusDurationSeconds` and `currentBreakDurationSeconds` to track the intended session durations.  
- Hook into existing Pomodoro lifecycle in `AppState` so the app: calls `refreshDailyStatsForCurrentDay()` when a work session starts, sets the appropriate current durations when entering running/break states, and only logs via `logFocusSessionIfNeeded()` / `logBreakSessionIfNeeded()` when a session actually reaches zero and transitions (so pauses/resets do not count).  
- Implement helpers in `AppState`: `refreshDailyStatsForCurrentDay()`, `logFocusSessionIfNeeded()`, `logBreakSessionIfNeeded()`, `updateDailyStats(_:)`, and `breakDurationSeconds(for:)` to keep updates immutable and explicit.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696c5b1921088323a51a8d6269078fdf)