### PR TITLE
Add daily summary stats persistence and UI

### DIFF
--- a/macos/Pomodoro/Pomodoro/DailyStats.swift
+++ b/macos/Pomodoro/Pomodoro/DailyStats.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct DailyStats: Equatable {
+struct DailyStats: Codable, Equatable {
     private(set) var dayStart: Date
     private(set) var totalFocusSeconds: Int
     private(set) var totalBreakSeconds: Int


### PR DESCRIPTION
### Motivation
- Provide a simple daily summary UI showing today’s focus/break time and completed sessions and persist those stats so they restore correctly across relaunches.  
- Ensure stats roll over at day boundaries and remain accurate when sessions start/complete.

### Description
- Made `DailyStats` conform to `Codable` to enable JSON encoding/decoding for persistence.  
- Added load/save helpers in `AppState` that use `JSONDecoder`/`JSONEncoder` and store data under `DefaultsKey.dailyStats`, and load stored stats at initialization via `Self.loadDailyStats(from:)`.  
- Persist `dailyStats` whenever it is updated by saving in `updateDailyStats(_:)` and call `refreshDailyStatsForCurrentDay()` on startup to ensure the stored stats are valid for today.  
- Added a compact "Today's Summary" section to `MainWindowView` including `SummaryRow`, `formattedDuration(_:)`, and logic to show either an empty message or the focus/break/session values from `appState.dailyStats`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696c6d604310832387fd1ca036f58659)