### PR TITLE
Update menu bar mode labeling

### DIFF
--- a/macos/PomodoroApp/DebugStateView.swift
+++ b/macos/PomodoroApp/DebugStateView.swift
@@ -5,7 +5,7 @@ struct DebugStateView: View {
 
     var body: some View {
         VStack {
-            Text("currentMode: \(String(describing: appState.currentMode))")
+            Text("currentMode: \(appState.currentMode.displayName)")
             Text("completedWorkSessions: \(appState.completedWorkSessions)")
             Text("workDuration: \(appState.workDuration)")
             Text("breakDuration: \(appState.breakDuration)")

--- a/macos/PomodoroApp/MenuBarController.swift
+++ b/macos/PomodoroApp/MenuBarController.swift
@@ -18,19 +18,17 @@ final class MenuBarController {
     }
 
     private func observeAppState() {
-        stateObserver = appState.objectWillChange.sink { [weak self] in
+        stateObserver = appState.$currentMode.sink { [weak self] _ in
             self?.handleStateChange()
         }
     }
 
     private func handleStateChange() {
-        // No-op for now; observing keeps menu in sync when state changes are added.
+        updateStatusItemTitle()
     }
 
     private func configureStatusItem() {
-        if let button = statusItem.button {
-            button.title = "Pomodoro"
-        }
+        updateStatusItemTitle()
 
         let menu = NSMenu()
         let openItem = NSMenuItem(
@@ -51,6 +49,12 @@ final class MenuBarController {
         menu.addItem(quitItem)
 
         statusItem.menu = menu
+    }
+
+    private func updateStatusItemTitle() {
+        guard let button = statusItem.button else { return }
+        let modeName = appState.currentMode.displayName
+        button.title = appState.currentMode == .idle ? "Pomodoro" : "Pomodoro • \(modeName)"
     }
 
     @objc private func openMainWindowAction() {

--- a/macos/PomodoroApp/PomodoroMode.swift
+++ b/macos/PomodoroApp/PomodoroMode.swift
@@ -6,3 +6,18 @@ enum PomodoroMode {
     case break
     case longBreak
 }
+
+extension PomodoroMode {
+    var displayName: String {
+        switch self {
+        case .idle:
+            return "Idle"
+        case .work:
+            return "Focus"
+        case .break:
+            return "Break"
+        case .longBreak:
+            return "Long Break"
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide user-friendly names for pomodoro modes and surface the current mode in the macOS menu bar so the app status is clearer at-a-glance.

### Description
- Added a `displayName` computed property to `PomodoroMode` to map internal modes to user-facing labels.
- Updated `DebugStateView` to show `appState.currentMode.displayName` instead of the enum debug description.
- Changed `MenuBarController` to observe `appState.$currentMode`, call `updateStatusItemTitle`, and display either `"Pomodoro"` or `"Pomodoro • <ModeName>"` depending on the mode.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696c6eeb3af8832392926d6cf33269d4)