### PR TITLE
Improve typography, button behavior, window persistence, and add keyboard shortcuts

### DIFF
--- a/macos/Pomodoro/Pomodoro/AppDelegate.swift
+++ b/macos/Pomodoro/Pomodoro/AppDelegate.swift
@@ -12,6 +12,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private weak var mainWindow: NSWindow?
     private var appStateConfigured = false
     private var menuBarController: MenuBarController?
+    private let mainWindowFrameAutosaveName = "PomodoroMainWindowFrame"
 
     var appState: AppState? {
         didSet {
@@ -38,6 +39,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         menuBarController?.shutdown()
     }
 
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        if let window = existingWindow() {
+            configureWindowPersistence(window)
+        }
+    }
+
     func openMainWindow() {
         guard let appState else { return }
 
@@ -57,7 +64,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         window.contentViewController = NSHostingController(
             rootView: ContentView().environmentObject(appState)
         )
-        window.center()
+        configureWindowPersistence(window)
         window.makeKeyAndOrderFront(nil)
         focus(window: window)
         mainWindow = window
@@ -83,5 +90,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             window.deminiaturize(nil)
         }
         window.makeKeyAndOrderFront(nil)
+    }
+
+    private func configureWindowPersistence(_ window: NSWindow) {
+        window.setFrameAutosaveName(mainWindowFrameAutosaveName)
+        if !window.setFrameUsingName(mainWindowFrameAutosaveName) {
+            window.center()
+        }
     }
 }

--- a/macos/Pomodoro/Pomodoro/AppState.swift
+++ b/macos/Pomodoro/Pomodoro/AppState.swift
@@ -199,6 +199,17 @@ final class AppState: ObservableObject {
         pomodoro.start()
     }
 
+    func startOrPausePomodoro() {
+        switch pomodoro.state {
+        case .idle:
+            pomodoro.start()
+        case .running, .breakRunning:
+            pomodoro.pause()
+        case .paused, .breakPaused:
+            pomodoro.resume()
+        }
+    }
+
     func togglePomodoroPause() {
         switch pomodoro.state {
         case .running, .breakRunning:

--- a/macos/Pomodoro/Pomodoro/MainWindowView.swift
+++ b/macos/Pomodoro/Pomodoro/MainWindowView.swift
@@ -18,16 +18,19 @@ struct MainWindowView: View {
         VStack(alignment: .leading, spacing: 16) {
             VStack(alignment: .leading, spacing: 8) {
                 Text(titleForPomodoroMode(appState.pomodoroMode))
-                    .font(.headline)
+                    .font(.system(.headline, design: .rounded))
+                    .foregroundStyle(.secondary)
                 Text(formattedTime(appState.pomodoro.remainingSeconds))
-                    .font(.title)
+                    .font(.system(size: 48, weight: .semibold, design: .rounded).monospacedDigit())
                 Text("State: \(labelForPomodoroState(appState.pomodoro.state))")
-                    .font(.subheadline)
+                    .font(.system(.subheadline, design: .rounded))
+                    .foregroundStyle(.secondary)
             }
 
             VStack(alignment: .leading, spacing: 8) {
                 Text("Preset")
-                    .font(.headline)
+                    .font(.system(.headline, design: .rounded))
+                    .foregroundStyle(.secondary)
                 Picker("Preset", selection: presetSelectionBinding) {
                     ForEach(Preset.builtIn) { preset in
                         Text(preset.name)
@@ -39,31 +42,29 @@ struct MainWindowView: View {
                 .pickerStyle(.segmented)
             }
 
-            HStack(spacing: 12) {
-                Button("Start") {
+            HStack(spacing: 10) {
+                let actions = pomodoroActions(for: appState.pomodoro.state)
+                ActionButton("Start", isEnabled: actions.canStart) {
                     appState.pomodoro.start()
                 }
-                .disabled(!pomodoroActions(for: appState.pomodoro.state).canStart)
-                Button("Pause") {
+                ActionButton("Pause", isEnabled: actions.canPause) {
                     appState.pomodoro.pause()
                 }
-                .disabled(!pomodoroActions(for: appState.pomodoro.state).canPause)
-                Button("Resume") {
+                ActionButton("Resume", isEnabled: actions.canResume) {
                     appState.pomodoro.resume()
                 }
-                .disabled(!pomodoroActions(for: appState.pomodoro.state).canResume)
-                Button("Reset") {
+                ActionButton("Reset") {
                     appState.pomodoro.reset()
                 }
-                Button("Skip Break") {
+                ActionButton("Skip Break", isEnabled: actions.canSkipBreak) {
                     appState.pomodoro.skipBreak()
                 }
-                .disabled(!pomodoroActions(for: appState.pomodoro.state).canSkipBreak)
             }
 
             VStack(alignment: .leading, spacing: 8) {
                 Text("Durations")
-                    .font(.headline)
+                    .font(.system(.headline, design: .rounded))
+                    .foregroundStyle(.secondary)
                 DurationInputRow(
                     title: "Work",
                     text: $workMinutesText,
@@ -97,7 +98,8 @@ struct MainWindowView: View {
 
             VStack(alignment: .leading, spacing: 8) {
                 Text("Notifications")
-                    .font(.headline)
+                    .font(.system(.headline, design: .rounded))
+                    .foregroundStyle(.secondary)
                 Picker("Notifications", selection: $appState.notificationPreference) {
                     ForEach(NotificationPreference.allCases) { preference in
                         Text(preference.title)
@@ -119,27 +121,27 @@ struct MainWindowView: View {
 
             VStack(alignment: .leading, spacing: 8) {
                 Text("Countdown")
-                    .font(.headline)
+                    .font(.system(.headline, design: .rounded))
+                    .foregroundStyle(.secondary)
                 Text(formattedTime(appState.countdown.remainingSeconds))
-                    .font(.title)
+                    .font(.system(size: 40, weight: .semibold, design: .rounded).monospacedDigit())
                 Text("State: \(appState.countdown.state.rawValue.capitalized)")
-                    .font(.subheadline)
+                    .font(.system(.subheadline, design: .rounded))
+                    .foregroundStyle(.secondary)
             }
 
-            HStack(spacing: 12) {
-                Button("Start") {
+            HStack(spacing: 10) {
+                let actions = countdownActions(for: appState.countdown.state)
+                ActionButton("Start", isEnabled: actions.canStart) {
                     appState.countdown.start()
                 }
-                .disabled(!countdownActions(for: appState.countdown.state).canStart)
-                Button("Pause") {
+                ActionButton("Pause", isEnabled: actions.canPause) {
                     appState.countdown.pause()
                 }
-                .disabled(!countdownActions(for: appState.countdown.state).canPause)
-                Button("Resume") {
+                ActionButton("Resume", isEnabled: actions.canResume) {
                     appState.countdown.resume()
                 }
-                .disabled(!countdownActions(for: appState.countdown.state).canResume)
-                Button("Reset") {
+                ActionButton("Reset") {
                     appState.countdown.reset()
                 }
             }
@@ -148,7 +150,8 @@ struct MainWindowView: View {
 
             VStack(alignment: .leading, spacing: 8) {
                 Text("Today's Summary")
-                    .font(.headline)
+                    .font(.system(.headline, design: .rounded))
+                    .foregroundStyle(.secondary)
                 summarySection
             }
         }
@@ -185,6 +188,7 @@ struct MainWindowView: View {
         var body: some View {
             HStack {
                 Text(title)
+                    .font(.system(.body, design: .rounded))
                 Spacer()
                 HStack(spacing: 6) {
                     TextField("", text: $text)
@@ -202,11 +206,40 @@ struct MainWindowView: View {
                         }
                     Text("min")
                         .foregroundStyle(.secondary)
+                        .font(.system(.callout, design: .rounded))
                 }
             }
             .accessibilityElement(children: .combine)
             .accessibilityLabel("\(title) minutes")
             .accessibilityHint("Enter a number and press return")
+        }
+    }
+
+    private struct ActionButton: View {
+        let title: String
+        let isEnabled: Bool
+        let action: () -> Void
+        @State private var isHovering = false
+
+        init(_ title: String, isEnabled: Bool = true, action: @escaping () -> Void) {
+            self.title = title
+            self.isEnabled = isEnabled
+            self.action = action
+        }
+
+        var body: some View {
+            Button(title, action: action)
+                .buttonStyle(.bordered)
+                .controlSize(.regular)
+                .disabled(!isEnabled)
+                .opacity(isEnabled ? 1.0 : 0.45)
+                .background(
+                    RoundedRectangle(cornerRadius: 6)
+                        .fill(isHovering && isEnabled ? Color.accentColor.opacity(0.08) : .clear)
+                )
+                .onHover { hovering in
+                    isHovering = hovering
+                }
         }
     }
 
@@ -260,6 +293,7 @@ struct MainWindowView: View {
             case .empty:
                 Text("No sessions logged yet today.")
                     .foregroundStyle(.secondary)
+                    .font(.system(.subheadline, design: .rounded))
             case .stats(let stats):
                 VStack(alignment: .leading, spacing: 6) {
                     SummaryRow(title: "Focus time", value: formattedDuration(stats.totalFocusSeconds))

--- a/macos/Pomodoro/Pomodoro/PomodoroApp.swift
+++ b/macos/Pomodoro/Pomodoro/PomodoroApp.swift
@@ -20,5 +20,26 @@ struct PomodoroApp: App {
                     appDelegate.appState = appState
                 }
         }
+        .commands {
+            CommandMenu("Timer") {
+                Button("Start/Pause Pomodoro") {
+                    appState.startOrPausePomodoro()
+                }
+                .keyboardShortcut(.space, modifiers: [])
+
+                Button("Reset Pomodoro") {
+                    appState.resetPomodoro()
+                }
+                .keyboardShortcut("r", modifiers: [])
+
+                Divider()
+
+                Button("Start Countdown") {
+                    appState.startCountdown()
+                }
+                .keyboardShortcut("c", modifiers: [.command, .shift])
+                .disabled(appState.countdown.state != .idle)
+            }
+        }
     }
 }


### PR DESCRIPTION
### Motivation
- Make the main timers and labels more readable and visually balanced using SF system fonts and subdued secondary text. 
- Improve button affordances so enabled/disabled states and hover feedback are clearer and spacing is consistent. 
- Restore the app window to its previous size/position across launches to match macOS expectations. 
- Provide convenient keyboard shortcuts for the common timer actions.

### Description
- Updated timer and label typography to use SF system fonts (rounded design), larger monospaced digits for timers, and subdued secondary labels across the UI (`MainWindowView.swift`).
- Replaced raw `Button` usages with a small `ActionButton` view to provide clear disabled opacity and hover background feedback, and standardized spacing between controls (`MainWindowView.swift`).
- Added `startOrPausePomodoro()` to `AppState` to implement a single start/pause toggle that the keyboard shortcut uses (`AppState.swift`).
- Added a `CommandMenu("Timer")` with keyboard shortcuts: Space → Start/Pause Pomodoro, `r` → Reset Pomodoro, `⌘⇧C` → Start Countdown (menu item disabled when countdown is not idle) (`PomodoroApp.swift`).
- Persist and restore the main window frame by setting an autosave name and attempting to restore the frame on launch, with fallback centering (`AppDelegate.swift`).

### Testing
- No automated tests were run on the modified code in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696c725937d883238b53bc8fac4ea157)