### PR TITLE
Synthesize focus sounds in-memory; remove bundled WAV resources and add music UI/controller

### DIFF
--- a/macos/Pomodoro/Pomodoro.xcodeproj/project.pbxproj
+++ b/macos/Pomodoro/Pomodoro.xcodeproj/project.pbxproj
@@ -21,6 +21,9 @@
 		7C360D6B2F191F17007313D3 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C360D6C2F191F17007313D3 /* AppDelegate.swift */; };
 		7C360D5D2F191F17007313D3 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 7C360D562F191F17007313D3 /* Assets.xcassets */; };
 		7C360D752F191F17007313D3 /* NotificationPreference.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C360D762F191F17007313D3 /* NotificationPreference.swift */; };
+		7C360D902F191F17007313D3 /* MusicController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C360D962F191F17007313D3 /* MusicController.swift */; };
+		7C360D912F191F17007313D3 /* SystemMediaController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C360D972F191F17007313D3 /* SystemMediaController.swift */; };
+		7C360D922F191F17007313D3 /* MusicPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C360D982F191F17007313D3 /* MusicPanelView.swift */; };
 		EC7658622FEE47D78BFEA957 /* DailyStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D409152AD794BA998253C35 /* DailyStats.swift */; };
 /* End PBXBuildFile section */
 
@@ -40,6 +43,9 @@
 		7C360D6C2F191F17007313D3 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		7C360D562F191F17007313D3 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		7C360D762F191F17007313D3 /* NotificationPreference.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationPreference.swift; sourceTree = "<group>"; };
+		7C360D962F191F17007313D3 /* MusicController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicController.swift; sourceTree = "<group>"; };
+		7C360D972F191F17007313D3 /* SystemMediaController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemMediaController.swift; sourceTree = "<group>"; };
+		7C360D982F191F17007313D3 /* MusicPanelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicPanelView.swift; sourceTree = "<group>"; };
 		0D409152AD794BA998253C35 /* DailyStats.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyStats.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -66,6 +72,7 @@
 			isa = PBXGroup;
 			children = (
 				7C360D5E2F191F17007313D3 /* App */,
+				7C360D9C2F191F17007313D3 /* Music */,
 				7C360D5F2F191F17007313D3 /* State */,
 				7C360D602F191F17007313D3 /* Timer */,
 				7C360D612F191F17007313D3 /* UI */,
@@ -120,14 +127,25 @@
 			children = (
 				7C360D532F191F17007313D3 /* ContentView.swift */,
 				7C360D542F191F17007313D3 /* MainWindowView.swift */,
+				7C360D982F191F17007313D3 /* MusicPanelView.swift */,
 			);
 			name = UI;
+			sourceTree = "<group>";
+		};
+		7C360D9C2F191F17007313D3 /* Music */ = {
+			isa = PBXGroup;
+			children = (
+				7C360D962F191F17007313D3 /* MusicController.swift */,
+				7C360D972F191F17007313D3 /* SystemMediaController.swift */,
+			);
+			name = Music;
 			sourceTree = "<group>";
 		};
 		7C360D622F191F17007313D3 /* Assets */ = {
 			isa = PBXGroup;
 			children = (
 				7C360D562F191F17007313D3 /* Assets.xcassets */,
+				
 			);
 			name = Assets;
 			sourceTree = "<group>";
@@ -206,9 +224,12 @@
 			files = (
 				7C360D5A2F191F17007313D3 /* ContentView.swift in Sources */,
 				7C360D5B2F191F17007313D3 /* MainWindowView.swift in Sources */,
+				7C360D922F191F17007313D3 /* MusicPanelView.swift in Sources */,
 				7C360D5C2F191F17007313D3 /* PomodoroApp.swift in Sources */,
 				7C360D6B2F191F17007313D3 /* AppDelegate.swift in Sources */,
 				7C360D6A2F191F17007313D3 /* MenuBarController.swift in Sources */,
+				7C360D902F191F17007313D3 /* MusicController.swift in Sources */,
+				7C360D912F191F17007313D3 /* SystemMediaController.swift in Sources */,
 				7C360D572F191F17007313D3 /* AppState.swift in Sources */,
 				EC7658622FEE47D78BFEA957 /* DailyStats.swift in Sources */,
 				7C360D6D2F191F17007313D3 /* DurationConfig.swift in Sources */,

--- a/macos/Pomodoro/Pomodoro/ContentView.swift
+++ b/macos/Pomodoro/Pomodoro/ContentView.swift
@@ -16,4 +16,5 @@ struct ContentView: View {
 #Preview {
     ContentView()
         .environmentObject(AppState())
+        .environmentObject(MusicController())
 }

--- a/macos/Pomodoro/Pomodoro/MusicController.swift
+++ b/macos/Pomodoro/Pomodoro/MusicController.swift
@@ -1,0 +1,307 @@
+//
+//  MusicController.swift
+//  Pomodoro
+//
+//  Created by Zhengyang Hu on 1/15/26.
+//
+
+import AVFoundation
+import MediaPlayer
+
+enum MusicPlaybackState: String {
+    case idle
+    case playing
+    case paused
+}
+
+enum MusicSource {
+    case none
+    case system
+    case focusSound
+}
+
+enum FocusSoundType: String, CaseIterable, Identifiable {
+    case off
+    case white
+    case brown
+    case rain
+    case wind
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .off:
+            return "Off"
+        case .white:
+            return "White"
+        case .brown:
+            return "Brown"
+        case .rain:
+            return "Rain"
+        case .wind:
+            return "Wind"
+        }
+    }
+
+    var resourceName: String? {
+        switch self {
+        case .off:
+            return nil
+        case .white:
+            return "white"
+        case .brown:
+            return "brown"
+        case .rain:
+            return "rain"
+        case .wind:
+            return "wind"
+        }
+    }
+}
+
+final class MusicController: ObservableObject {
+    @Published private(set) var playbackState: MusicPlaybackState
+    @Published private(set) var activeSource: MusicSource
+    @Published var currentFocusSound: FocusSoundType
+
+    private let systemMediaController: SystemMediaController
+    private let userDefaults: UserDefaults
+    private var focusPlayer: AVAudioPlayer?
+
+    init(
+        systemMediaController: SystemMediaController = SystemMediaController(),
+        userDefaults: UserDefaults = .standard
+    ) {
+        self.systemMediaController = systemMediaController
+        self.userDefaults = userDefaults
+        let storedFocus = FocusSoundType(rawValue: userDefaults.string(forKey: "music.focusSound") ?? "") ?? .off
+        let storedPlayback = MusicPlaybackState(rawValue: userDefaults.string(forKey: "music.playbackState") ?? "") ?? .idle
+        currentFocusSound = storedFocus
+        playbackState = storedPlayback
+        activeSource = storedFocus == .off ? .none : .focusSound
+        if storedFocus == .off {
+            let systemState = Self.mapSystemPlaybackState(MPNowPlayingInfoCenter.default().playbackState)
+            playbackState = systemState
+            activeSource = systemState == .idle ? .none : .system
+        } else if storedPlayback == .playing {
+            startFocusSound(storedFocus)
+        }
+    }
+
+    func play() {
+        if activeSource == .focusSound, currentFocusSound != .off {
+            startFocusSound(currentFocusSound)
+            return
+        }
+        stopFocusSoundPlayback(keepSelection: true)
+        systemMediaController.playPause()
+        activeSource = .system
+        playbackState = .playing
+        persistState()
+    }
+
+    func pause() {
+        switch activeSource {
+        case .focusSound:
+            stopFocusSoundPlayback(keepSelection: true)
+            playbackState = .paused
+            persistState()
+        case .system:
+            pauseSystemIfNeeded()
+            playbackState = .paused
+            persistState()
+        case .none:
+            playbackState = .paused
+            persistState()
+        }
+    }
+
+    func next() {
+        stopFocusSoundPlayback(keepSelection: true)
+        systemMediaController.nextTrack()
+        activeSource = .system
+        playbackState = .playing
+        persistState()
+    }
+
+    func previous() {
+        stopFocusSoundPlayback(keepSelection: true)
+        systemMediaController.previousTrack()
+        activeSource = .system
+        playbackState = .playing
+        persistState()
+    }
+
+    func startFocusSound(_ type: FocusSoundType) {
+        guard type != .off else {
+            stopFocusSound()
+            return
+        }
+        stopFocusSoundPlayback(keepSelection: false)
+        pauseSystemIfNeeded()
+        currentFocusSound = type
+        if let player = makeFocusPlayer(for: type) {
+            focusPlayer = player
+            player.numberOfLoops = -1
+            player.play()
+            playbackState = .playing
+            activeSource = .focusSound
+        } else {
+            playbackState = .idle
+            activeSource = .none
+        }
+        persistState()
+    }
+
+    func stopFocusSound() {
+        stopFocusSoundPlayback(keepSelection: false)
+        currentFocusSound = .off
+        activeSource = .none
+        playbackState = .idle
+        persistState()
+    }
+
+    private func stopFocusSoundPlayback(keepSelection: Bool) {
+        focusPlayer?.stop()
+        focusPlayer = nil
+        if !keepSelection {
+            currentFocusSound = .off
+        }
+        if activeSource == .focusSound {
+            activeSource = keepSelection ? .focusSound : .none
+        }
+    }
+
+    private func makeFocusPlayer(for type: FocusSoundType) -> AVAudioPlayer? {
+        if let resourceName = type.resourceName,
+           let url = Bundle.main.url(forResource: resourceName, withExtension: "wav") {
+            do {
+                let player = try AVAudioPlayer(contentsOf: url)
+                player.prepareToPlay()
+                return player
+            } catch {
+                return nil
+            }
+        }
+
+        guard let data = makeSynthesizedWavData(for: type) else {
+            return nil
+        }
+
+        do {
+            let player = try AVAudioPlayer(data: data)
+            player.prepareToPlay()
+            return player
+        } catch {
+            return nil
+        }
+    }
+
+    private func makeSynthesizedWavData(for type: FocusSoundType) -> Data? {
+        guard type != .off else { return nil }
+
+        let sampleRate = 44_100
+        let durationSeconds = 5
+        let frameCount = sampleRate * durationSeconds
+        let channelCount = 1
+        let bitsPerSample = 16
+        let bytesPerSample = bitsPerSample / 8
+        let blockAlign = channelCount * bytesPerSample
+        let byteRate = sampleRate * blockAlign
+        let dataByteCount = frameCount * blockAlign
+
+        var samples = [Int16]()
+        samples.reserveCapacity(frameCount)
+
+        var brownAccumulator: Double = 0
+        var rainDropEnvelope: Double = 0
+        var windModulationPhase: Double = 0
+
+        for _ in 0..<frameCount {
+            let white = Double.random(in: -1...1)
+            var sample: Double
+
+            switch type {
+            case .white:
+                sample = white
+            case .brown:
+                brownAccumulator = (brownAccumulator + white * 0.02).clamped(to: -1...1)
+                sample = brownAccumulator * 1.2
+            case .rain:
+                rainDropEnvelope = max(rainDropEnvelope - 0.003, 0)
+                if Double.random(in: 0...1) > 0.995 {
+                    rainDropEnvelope = Double.random(in: 0.4...1.0)
+                }
+                let hiss = white * 0.3
+                let drops = rainDropEnvelope * Double.random(in: -1...1) * 0.7
+                sample = hiss + drops
+            case .wind:
+                windModulationPhase += 0.0008
+                let modulator = (sin(windModulationPhase * .pi * 2) + 1) * 0.5
+                sample = white * (0.2 + 0.8 * modulator)
+            case .off:
+                sample = 0
+            }
+
+            let clipped = max(-1.0, min(1.0, sample))
+            samples.append(Int16(clipped * Double(Int16.max)))
+        }
+
+        var data = Data()
+        data.reserveCapacity(44 + dataByteCount)
+        data.append(contentsOf: "RIFF".utf8)
+        data.append(UInt32(36 + dataByteCount).littleEndianBytes)
+        data.append(contentsOf: "WAVE".utf8)
+        data.append(contentsOf: "fmt ".utf8)
+        data.append(UInt32(16).littleEndianBytes)
+        data.append(UInt16(1).littleEndianBytes)
+        data.append(UInt16(channelCount).littleEndianBytes)
+        data.append(UInt32(sampleRate).littleEndianBytes)
+        data.append(UInt32(byteRate).littleEndianBytes)
+        data.append(UInt16(blockAlign).littleEndianBytes)
+        data.append(UInt16(bitsPerSample).littleEndianBytes)
+        data.append(contentsOf: "data".utf8)
+        data.append(UInt32(dataByteCount).littleEndianBytes)
+
+        for sample in samples {
+            data.append(sample.littleEndianBytes)
+        }
+
+        return data
+    }
+
+    private func pauseSystemIfNeeded() {
+        if MPNowPlayingInfoCenter.default().playbackState == .playing {
+            systemMediaController.playPause()
+        }
+    }
+
+    private func persistState() {
+        userDefaults.set(currentFocusSound.rawValue, forKey: "music.focusSound")
+        userDefaults.set(playbackState.rawValue, forKey: "music.playbackState")
+    }
+
+    private static func mapSystemPlaybackState(_ state: MPNowPlayingPlaybackState) -> MusicPlaybackState {
+        switch state {
+        case .playing:
+            return .playing
+        case .paused:
+            return .paused
+        default:
+            return .idle
+        }
+    }
+}
+
+private extension Double {
+    func clamped(to range: ClosedRange<Double>) -> Double {
+        min(max(self, range.lowerBound), range.upperBound)
+    }
+}
+
+private extension FixedWidthInteger {
+    var littleEndianBytes: [UInt8] {
+        withUnsafeBytes(of: self.littleEndian, Array.init)
+    }
+}

--- a/macos/Pomodoro/Pomodoro/MusicPanelView.swift
+++ b/macos/Pomodoro/Pomodoro/MusicPanelView.swift
@@ -1,0 +1,77 @@
+//
+//  MusicPanelView.swift
+//  Pomodoro
+//
+//  Created by Zhengyang Hu on 1/15/26.
+//
+
+import SwiftUI
+
+struct MusicPanelView: View {
+    @EnvironmentObject private var musicController: MusicController
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            HStack(spacing: 12) {
+                Button(action: { musicController.previous() }) {
+                    Image(systemName: "backward.fill")
+                }
+                .buttonStyle(.borderless)
+                .disabled(musicController.activeSource == .focusSound)
+
+                Button(action: togglePlayback) {
+                    Image(systemName: musicController.playbackState == .playing ? "pause.fill" : "play.fill")
+                }
+                .buttonStyle(.borderless)
+
+                Button(action: { musicController.next() }) {
+                    Image(systemName: "forward.fill")
+                }
+                .buttonStyle(.borderless)
+                .disabled(musicController.activeSource == .focusSound)
+            }
+            .font(.system(size: 18, weight: .semibold))
+
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Focus Sound")
+                    .font(.system(.subheadline, design: .rounded))
+                    .foregroundStyle(.secondary)
+                Picker("Focus Sound", selection: focusSoundBinding) {
+                    ForEach(FocusSoundType.allCases) { sound in
+                        Text(sound.displayName)
+                            .tag(sound)
+                    }
+                }
+                .pickerStyle(.segmented)
+            }
+        }
+        .padding(20)
+        .frame(minWidth: 280)
+    }
+
+    private var focusSoundBinding: Binding<FocusSoundType> {
+        Binding(
+            get: { musicController.currentFocusSound },
+            set: { newValue in
+                if newValue == .off {
+                    musicController.stopFocusSound()
+                } else {
+                    musicController.startFocusSound(newValue)
+                }
+            }
+        )
+    }
+
+    private func togglePlayback() {
+        if musicController.playbackState == .playing {
+            musicController.pause()
+        } else {
+            musicController.play()
+        }
+    }
+}
+
+#Preview {
+    MusicPanelView()
+        .environmentObject(MusicController())
+}

--- a/macos/Pomodoro/Pomodoro/PomodoroApp.swift
+++ b/macos/Pomodoro/Pomodoro/PomodoroApp.swift
@@ -11,13 +11,16 @@ import SwiftUI
 struct PomodoroApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
     @StateObject private var appState = AppState()
+    @StateObject private var musicController = MusicController()
 
     var body: some Scene {
         WindowGroup {
             ContentView()
                 .environmentObject(appState)
+                .environmentObject(musicController)
                 .task(id: ObjectIdentifier(appState)) {
                     appDelegate.appState = appState
+                    appDelegate.musicController = musicController
                 }
         }
         .commands {

--- a/macos/Pomodoro/Pomodoro/SystemMediaController.swift
+++ b/macos/Pomodoro/Pomodoro/SystemMediaController.swift
@@ -1,0 +1,53 @@
+//
+//  SystemMediaController.swift
+//  Pomodoro
+//
+//  Created by Zhengyang Hu on 1/15/26.
+//
+
+import AppKit
+
+struct SystemMediaController {
+    private enum MediaKey: Int32 {
+        case playPause = 16
+        case next = 17
+        case previous = 18
+    }
+
+    func playPause() {
+        postMediaKey(.playPause)
+    }
+
+    func nextTrack() {
+        postMediaKey(.next)
+    }
+
+    func previousTrack() {
+        postMediaKey(.previous)
+    }
+
+    private func postMediaKey(_ key: MediaKey) {
+        postMediaKey(key, keyDown: true)
+        postMediaKey(key, keyDown: false)
+    }
+
+    private func postMediaKey(_ key: MediaKey, keyDown: Bool) {
+        let keyCode = key.rawValue
+        let keyState: Int32 = keyDown ? 0xA00 : 0xB00
+        let data1 = (keyCode << 16) | keyState
+        guard let event = NSEvent.otherEvent(
+            with: .systemDefined,
+            location: .zero,
+            modifierFlags: [],
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            subtype: 8,
+            data1: Int(data1),
+            data2: -1
+        ) else {
+            return
+        }
+        event.cgEvent?.post(tap: .cghidEventTap)
+    }
+}


### PR DESCRIPTION
### Motivation
- Remove binary .wav files from the repository and avoid shipping resource artifacts while preserving ambient focus sound playback.
- Add a wind ambient option and provide a robust fallback when bundled audio assets are absent.
- Expose basic music controls and a small music panel to let users play/pause, skip tracks, and choose focus sounds.

### Description
- Implement `MusicController` with playback state handling, `FocusSoundType` (including `wind`), and `makeSynthesizedWavData` to generate WAV data in-memory when a bundled resource is missing, and use `makeFocusPlayer` to create an `AVAudioPlayer` from resource or synthesized data.
- Remove the bundled focus sound files from the Xcode project (`project.pbxproj`) and delete the `FocusSounds` assets directory so playback relies on synthesized audio when files are not present.
- Add `MusicPanelView` and `SystemMediaController`, and wire `MusicController` into the app by updating `AppDelegate`, `PomodoroApp`, `ContentView` previews, and `MenuBarController` to show music controls and focus sound selection.
- Improve focus-sound playback state handling so `activeSource` is set only when an `AVAudioPlayer` is successfully created and persist the current focus sound and playback state in `UserDefaults` via `persistState`.

### Testing
- No automated tests were executed for these changes.
- Manual compile/run was not recorded in automated logs (no CI/build results provided).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696c7cc0d5888323972c97266ccbcae9)