### PR TITLE
Add LocalAudioPlayer and test playback button

### DIFF
--- a/macos/PomodoroApp/LocalAudioPlayer.swift
+++ b/macos/PomodoroApp/LocalAudioPlayer.swift
@@ -1,0 +1,63 @@
+import AVFoundation
+
+@MainActor
+final class LocalAudioPlayer: NSObject, ObservableObject {
+    private var audioPlayer: AVAudioPlayer?
+    private var currentResource: String?
+    private var currentExtension: String?
+
+    override init() {
+        super.init()
+        configureAudioSession()
+    }
+
+    func playBundledAudio(named resource: String, withExtension fileExtension: String, loop: Bool = false) {
+        guard let url = Bundle.main.url(forResource: resource, withExtension: fileExtension) else {
+            print("LocalAudioPlayer: Missing bundled audio file \(resource).\(fileExtension)")
+            return
+        }
+
+        if audioPlayer == nil || currentResource != resource || currentExtension != fileExtension {
+            loadPlayer(url: url, loop: loop)
+        } else {
+            audioPlayer?.numberOfLoops = loop ? -1 : 0
+        }
+
+        audioPlayer?.play()
+    }
+
+    func pause() {
+        audioPlayer?.pause()
+    }
+
+    func stop() {
+        audioPlayer?.stop()
+        audioPlayer?.currentTime = 0
+    }
+
+    private func loadPlayer(url: URL, loop: Bool) {
+        stop()
+        do {
+            let player = try AVAudioPlayer(contentsOf: url)
+            player.volume = 1.0
+            player.numberOfLoops = loop ? -1 : 0
+            player.prepareToPlay()
+            audioPlayer = player
+            currentResource = url.deletingPathExtension().lastPathComponent
+            currentExtension = url.pathExtension
+        } catch {
+            audioPlayer = nil
+            print("LocalAudioPlayer: Failed to load audio: \(error.localizedDescription)")
+        }
+    }
+
+    private func configureAudioSession() {
+        do {
+            let session = AVAudioSession.sharedInstance()
+            try session.setCategory(.playback, mode: .default, options: [.mixWithOthers])
+            try session.setActive(true)
+        } catch {
+            print("LocalAudioPlayer: Failed to configure audio session: \(error.localizedDescription)")
+        }
+    }
+}

--- a/macos/PomodoroApp/MainWindowView.swift
+++ b/macos/PomodoroApp/MainWindowView.swift
@@ -1,12 +1,18 @@
 import SwiftUI
 
 struct MainWindowView: View {
+    @StateObject private var audioPlayer = LocalAudioPlayer()
+
     var body: some View {
         VStack(spacing: 12) {
             Text("Pomodoro")
                 .font(.largeTitle)
             Text("Ready to focus.")
                 .foregroundStyle(.secondary)
+            Button("▶ Play Test Sound") {
+                audioPlayer.playBundledAudio(named: "test_music", withExtension: "wav")
+            }
+            .buttonStyle(.borderedProminent)
             DebugStateView()
         }
         .frame(minWidth: 480, minHeight: 320)


### PR DESCRIPTION
### Motivation

- Provide a real local audio player to enable bundled audio playback and to serve as the foundation for local music and ambient focus sounds.
- Ensure a single, safe AVAudioPlayer instance is used and add a quick UI hook to verify audible playback.

### Description

- Add `LocalAudioPlayer` (new `macos/PomodoroApp/LocalAudioPlayer.swift`) that wraps `AVAudioPlayer`, loads bundled files, and exposes `playBundledAudio(named:withExtension:loop:)`, `pause()`, and `stop()` methods.
- Configure audio playback session in `LocalAudioPlayer` and set player properties (`volume`, `numberOfLoops`, `prepareToPlay`) while ensuring only one `AVAudioPlayer` instance is used and previous playback is stopped before loading a new file.
- Handle missing or failing-to-load files gracefully by printing a descriptive message instead of crashing.
- Add a temporary test UI control (`▶ Play Test Sound`) to `MainWindowView` that calls `playBundledAudio(named: "test_music", withExtension: "wav")`.

### Testing

- Attempted an automated environment check via `swift -e 'import AVFoundation; _ = AVAudioSession.sharedInstance()'` which failed in this sandbox with `no such module 'AVFoundation'`, so runtime verification of audio could not be performed here (this is an environment limitation rather than a code failure).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696cb162fddc8323804743a5049d132b)