### PR TITLE
Add AVAudioEngine-based AmbientNoiseEngine and wire to MusicController

### DIFF
--- a/macos/Pomodoro/Pomodoro/AmbientNoiseEngine.swift
+++ b/macos/Pomodoro/Pomodoro/AmbientNoiseEngine.swift
@@ -1,0 +1,225 @@
+//
+//  AmbientNoiseEngine.swift
+//  Pomodoro
+//
+//  Created by OpenAI on 2025-02-11.
+//
+
+import AVFoundation
+import os
+
+final class AmbientNoiseEngine {
+    enum NoiseType {
+        case off
+        case white
+        case brown
+        case rain
+        case wind
+    }
+
+    private struct State {
+        var type: NoiseType
+        var volume: Float
+        var randomSeedL: UInt32
+        var randomSeedR: UInt32
+        var brownL: Float
+        var brownR: Float
+        var rainLpfL: Float
+        var rainLpfR: Float
+        var windLowL: Float
+        var windLowR: Float
+        var windHighL: Float
+        var windHighR: Float
+        var rainPhase: Float
+    }
+
+    private let engine = AVAudioEngine()
+    private let sourceNode: AVAudioSourceNode
+    private let format: AVAudioFormat
+    private let sampleRate: Double = 44_100
+    private let rainAlpha: Float
+    private let windLowAlpha: Float
+    private let windHighAlpha: Float
+    private let rainPhaseIncrement: Float
+    private var stateLock = os_unfair_lock_s()
+    private var state: State
+
+    init() {
+        format = AVAudioFormat(standardFormatWithSampleRate: sampleRate, channels: 2)
+        rainAlpha = AmbientNoiseEngine.alpha(for: 1200, sampleRate: sampleRate)
+        windLowAlpha = AmbientNoiseEngine.alpha(for: 2000, sampleRate: sampleRate)
+        windHighAlpha = AmbientNoiseEngine.alpha(for: 200, sampleRate: sampleRate)
+        rainPhaseIncrement = Float(2.0 * Double.pi * 0.5 / sampleRate)
+        state = State(
+            type: .off,
+            volume: 0.25,
+            randomSeedL: 0x12345678,
+            randomSeedR: 0x87654321,
+            brownL: 0,
+            brownR: 0,
+            rainLpfL: 0,
+            rainLpfR: 0,
+            windLowL: 0,
+            windLowR: 0,
+            windHighL: 0,
+            windHighR: 0,
+            rainPhase: 0
+        )
+
+        sourceNode = AVAudioSourceNode { [weak self] _, _, frameCount, audioBufferList in
+            guard let self else { return noErr }
+            let bufferList = UnsafeMutableAudioBufferListPointer(audioBufferList)
+            let frameCount = Int(frameCount)
+
+            os_unfair_lock_lock(&self.stateLock)
+            var state = self.state
+            os_unfair_lock_unlock(&self.stateLock)
+
+            let volume = state.volume
+            let type = state.type
+
+            if type == .off || volume <= 0 {
+                for buffer in bufferList {
+                    memset(buffer.mData, 0, Int(buffer.mDataByteSize))
+                }
+                return noErr
+            }
+
+            let channelCount = Int(bufferList.count)
+            let bufferL = bufferList[0]
+            let bufferR = channelCount > 1 ? bufferList[1] : bufferList[0]
+            let ptrL = bufferL.mData!.assumingMemoryBound(to: Float.self)
+            let ptrR = bufferR.mData!.assumingMemoryBound(to: Float.self)
+
+            for frame in 0..<frameCount {
+                let whiteL = Self.nextWhite(seed: &state.randomSeedL)
+                let whiteR = Self.nextWhite(seed: &state.randomSeedR)
+
+                let sampleL = self.renderSample(
+                    type: type,
+                    white: whiteL,
+                    brownState: &state.brownL,
+                    rainLpf: &state.rainLpfL,
+                    windLow: &state.windLowL,
+                    windHigh: &state.windHighL,
+                    rainPhase: &state.rainPhase
+                )
+
+                let sampleR = self.renderSample(
+                    type: type,
+                    white: whiteR,
+                    brownState: &state.brownR,
+                    rainLpf: &state.rainLpfR,
+                    windLow: &state.windLowR,
+                    windHigh: &state.windHighR,
+                    rainPhase: &state.rainPhase
+                )
+
+                ptrL[frame] = Self.clamp(sampleL * volume)
+                ptrR[frame] = Self.clamp(sampleR * volume)
+            }
+
+            os_unfair_lock_lock(&self.stateLock)
+            self.state.randomSeedL = state.randomSeedL
+            self.state.randomSeedR = state.randomSeedR
+            self.state.brownL = state.brownL
+            self.state.brownR = state.brownR
+            self.state.rainLpfL = state.rainLpfL
+            self.state.rainLpfR = state.rainLpfR
+            self.state.windLowL = state.windLowL
+            self.state.windLowR = state.windLowR
+            self.state.windHighL = state.windHighL
+            self.state.windHighR = state.windHighR
+            self.state.rainPhase = state.rainPhase
+            os_unfair_lock_unlock(&self.stateLock)
+
+            return noErr
+        }
+
+        engine.attach(sourceNode)
+        engine.connect(sourceNode, to: engine.mainMixerNode, format: format)
+        engine.prepare()
+    }
+
+    func play(type: NoiseType) {
+        os_unfair_lock_lock(&stateLock)
+        state.type = type
+        os_unfair_lock_unlock(&stateLock)
+
+        guard type != .off else {
+            stop()
+            return
+        }
+
+        if !engine.isRunning {
+            do {
+                try engine.start()
+            } catch {
+                return
+            }
+        }
+    }
+
+    func stop() {
+        os_unfair_lock_lock(&stateLock)
+        state.type = .off
+        os_unfair_lock_unlock(&stateLock)
+        engine.stop()
+    }
+
+    func setVolume(_ volume: Float) {
+        let clamped = max(0, min(volume, 1))
+        os_unfair_lock_lock(&stateLock)
+        state.volume = clamped
+        os_unfair_lock_unlock(&stateLock)
+    }
+
+    private func renderSample(
+        type: NoiseType,
+        white: Float,
+        brownState: inout Float,
+        rainLpf: inout Float,
+        windLow: inout Float,
+        windHigh: inout Float,
+        rainPhase: inout Float
+    ) -> Float {
+        switch type {
+        case .off:
+            return 0
+        case .white:
+            return white
+        case .brown:
+            brownState = (brownState + white * 0.02) / 1.02
+            return brownState * 3.5
+        case .rain:
+            rainLpf += (white - rainLpf) * rainAlpha
+            rainPhase += rainPhaseIncrement
+            if rainPhase > Float.pi * 2 {
+                rainPhase -= Float.pi * 2
+            }
+            let mod = 0.65 + 0.35 * sin(rainPhase)
+            return rainLpf * 0.7 * mod
+        case .wind:
+            brownState = (brownState + white * 0.02) / 1.02
+            windLow += (brownState - windLow) * windLowAlpha
+            windHigh += (brownState - windHigh) * windHighAlpha
+            let band = (windLow - windHigh) * 1.4
+            return band
+        }
+    }
+
+    private static func nextWhite(seed: inout UInt32) -> Float {
+        seed = 1664525 &* seed &+ 1013904223
+        let normalized = Float(seed) / Float(UInt32.max)
+        return normalized * 2 - 1
+    }
+
+    private static func clamp(_ value: Float) -> Float {
+        max(-1, min(1, value))
+    }
+
+    private static func alpha(for cutoff: Double, sampleRate: Double) -> Float {
+        let x = -2.0 * Double.pi * cutoff / sampleRate
+        return Float(1.0 - exp(x))
+    }
+}

--- a/macos/Pomodoro/Pomodoro/AppState.swift
+++ b/macos/Pomodoro/Pomodoro/AppState.swift
@@ -12,6 +12,7 @@ import UserNotifications
 final class AppState: ObservableObject {
     let pomodoro: PomodoroTimerEngine
     let countdown: CountdownTimerEngine
+    let ambientNoiseEngine: AmbientNoiseEngine
 
     @Published var durationConfig: DurationConfig {
         didSet {
@@ -56,10 +57,12 @@ final class AppState: ObservableObject {
         pomodoro: PomodoroTimerEngine,
         countdown: CountdownTimerEngine,
         durationConfig: DurationConfig,
-        userDefaults: UserDefaults
+        userDefaults: UserDefaults,
+        ambientNoiseEngine: AmbientNoiseEngine
     ) {
         self.pomodoro = pomodoro
         self.countdown = countdown
+        self.ambientNoiseEngine = ambientNoiseEngine
         self.durationConfig = durationConfig
         self.presetSelection = PresetSelection.selection(for: durationConfig)
         self.pomodoroMode = pomodoro.mode
@@ -138,14 +141,16 @@ final class AppState: ObservableObject {
     convenience init(
         pomodoro: PomodoroTimerEngine,
         countdown: CountdownTimerEngine,
-        userDefaults: UserDefaults
+        userDefaults: UserDefaults,
+        ambientNoiseEngine: AmbientNoiseEngine
     ) {
         let storedConfig = DurationConfig.load(from: userDefaults)
         self.init(
             pomodoro: pomodoro,
             countdown: countdown,
             durationConfig: storedConfig,
-            userDefaults: userDefaults
+            userDefaults: userDefaults,
+            ambientNoiseEngine: ambientNoiseEngine
         )
     }
 
@@ -157,7 +162,8 @@ final class AppState: ObservableObject {
         self.init(
             pomodoro: pomodoro,
             countdown: countdown,
-            userDefaults: .standard
+            userDefaults: .standard,
+            ambientNoiseEngine: AmbientNoiseEngine()
         )
     }
 

--- a/macos/Pomodoro/Pomodoro/ContentView.swift
+++ b/macos/Pomodoro/Pomodoro/ContentView.swift
@@ -14,7 +14,8 @@ struct ContentView: View {
 }
 
 #Preview {
+    let appState = AppState()
     ContentView()
-        .environmentObject(AppState())
-        .environmentObject(MusicController())
+        .environmentObject(appState)
+        .environmentObject(MusicController(ambientNoiseEngine: appState.ambientNoiseEngine))
 }

--- a/macos/Pomodoro/Pomodoro/MainWindowView.swift
+++ b/macos/Pomodoro/Pomodoro/MainWindowView.swift
@@ -503,6 +503,8 @@ struct MainWindowView: View {
 }
 
 #Preview {
+    let appState = AppState()
     MainWindowView()
-        .environmentObject(AppState())
+        .environmentObject(appState)
+        .environmentObject(MusicController(ambientNoiseEngine: appState.ambientNoiseEngine))
 }

--- a/macos/Pomodoro/Pomodoro/MusicPanelView.swift
+++ b/macos/Pomodoro/Pomodoro/MusicPanelView.swift
@@ -72,6 +72,7 @@ struct MusicPanelView: View {
 }
 
 #Preview {
+    let appState = AppState()
     MusicPanelView()
-        .environmentObject(MusicController())
+        .environmentObject(MusicController(ambientNoiseEngine: appState.ambientNoiseEngine))
 }

--- a/macos/Pomodoro/Pomodoro/PomodoroApp.swift
+++ b/macos/Pomodoro/Pomodoro/PomodoroApp.swift
@@ -10,8 +10,14 @@ import SwiftUI
 @main
 struct PomodoroApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
-    @StateObject private var appState = AppState()
-    @StateObject private var musicController = MusicController()
+    @StateObject private var appState: AppState
+    @StateObject private var musicController: MusicController
+
+    init() {
+        let appState = AppState()
+        _appState = StateObject(wrappedValue: appState)
+        _musicController = StateObject(wrappedValue: MusicController(ambientNoiseEngine: appState.ambientNoiseEngine))
+    }
 
     var body: some Scene {
         WindowGroup {


### PR DESCRIPTION
### Motivation
- Provide a real, audible ambient noise system generated in real time without using audio assets or static files. 
- Allow the existing Ambient Sound UI to control a continuously-looping AVAudioEngine generator that works while the app runs.

### Description
- Add `AmbientNoiseEngine.swift` implementing an `AVAudioEngine` with an `AVAudioSourceNode` that generates Float32 PCM at `44_100` Hz and exposes `play(type:)`, `stop()`, and `setVolume(_:)`. 
- Implement white, brown, rain, and wind noise algorithms (including simple filtering and modulation) and use `os_unfair_lock` to keep audio state thread-safe and avoid glitches/clipping. 
- Make `AppState` own a single shared `AmbientNoiseEngine` instance and pass it into `MusicController`. 
- Update `MusicController` to drive the engine for focus sounds (start/stop/select types) and remove prior file-based `AVAudioPlayer` usage so selecting a noise type produces immediate audible output. 
- Wire app initialization and SwiftUI previews to share the single engine instance so UI controls operate immediately and seamlessly without restarting the engine.

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696cd5b7993c83239f4367310dc4e1c2)