### PR TITLE
Add LocalMusicPlayer and wire into app state and music UI

### DIFF
--- a/macos/Pomodoro/Pomodoro/AppDelegate.swift
+++ b/macos/Pomodoro/Pomodoro/AppDelegate.swift
@@ -61,6 +61,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         window.contentViewController = NSHostingController(
             rootView: ContentView()
                 .environmentObject(appState)
+                .environmentObject(appState.localMusicPlayer)
                 .environmentObject(musicController)
         )
         configureWindowPersistence(window)
@@ -70,7 +71,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func openMusicPanel() {
-        guard let musicController else { return }
+        guard let appState else { return }
 
         if let window = musicWindow {
             focus(window: window)
@@ -86,7 +87,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         window.title = "Music"
         window.isReleasedWhenClosed = true
         window.contentViewController = NSHostingController(
-            rootView: MusicPanelView().environmentObject(musicController)
+            rootView: MusicPanelView().environmentObject(appState.localMusicPlayer)
         )
         configureWindowPersistence(window, autosaveName: musicWindowFrameAutosaveName)
         window.makeKeyAndOrderFront(nil)

--- a/macos/Pomodoro/Pomodoro/AppState.swift
+++ b/macos/Pomodoro/Pomodoro/AppState.swift
@@ -13,6 +13,7 @@ final class AppState: ObservableObject {
     let pomodoro: PomodoroTimerEngine
     let countdown: CountdownTimerEngine
     let ambientNoiseEngine: AmbientNoiseEngine
+    let localMusicPlayer: LocalMusicPlayer = LocalMusicPlayer()
 
     @Published var durationConfig: DurationConfig {
         didSet {

--- a/macos/Pomodoro/Pomodoro/ContentView.swift
+++ b/macos/Pomodoro/Pomodoro/ContentView.swift
@@ -17,5 +17,6 @@ struct ContentView: View {
     let appState = AppState()
     ContentView()
         .environmentObject(appState)
+        .environmentObject(appState.localMusicPlayer)
         .environmentObject(MusicController(ambientNoiseEngine: appState.ambientNoiseEngine))
 }

--- a/macos/Pomodoro/Pomodoro/LocalMusicPlayer.swift
+++ b/macos/Pomodoro/Pomodoro/LocalMusicPlayer.swift
@@ -1,0 +1,105 @@
+//
+//  LocalMusicPlayer.swift
+//  Pomodoro
+//
+//  Created by Zhengyang Hu on 1/15/26.
+//
+
+import AppKit
+import AVFoundation
+import SwiftUI
+import UniformTypeIdentifiers
+
+@MainActor
+final class LocalMusicPlayer: NSObject, ObservableObject {
+    @Published private(set) var isPlaying = false
+    @Published private(set) var currentTrackName: String?
+
+    private var audioPlayer: AVAudioPlayer?
+    private var fileURLs: [URL] = []
+    private var currentIndex = 0
+    private var volume: Float = 1.0
+
+    var hasFiles: Bool {
+        !fileURLs.isEmpty
+    }
+
+    func loadFiles() {
+        let panel = NSOpenPanel()
+        panel.canChooseFiles = true
+        panel.canChooseDirectories = false
+        panel.allowsMultipleSelection = true
+        panel.allowedContentTypes = [.mp3, .mpeg4Audio, .wav, .aiff]
+
+        if panel.runModal() == .OK {
+            fileURLs = panel.urls
+            currentIndex = 0
+            preparePlayer(at: currentIndex, shouldPlay: false)
+        }
+    }
+
+    func play() {
+        guard hasFiles else { return }
+        if audioPlayer == nil {
+            preparePlayer(at: currentIndex, shouldPlay: true)
+            return
+        }
+        audioPlayer?.play()
+        isPlaying = audioPlayer?.isPlaying ?? false
+    }
+
+    func pause() {
+        audioPlayer?.pause()
+        isPlaying = false
+    }
+
+    func next() {
+        guard hasFiles else { return }
+        let shouldPlay = isPlaying
+        currentIndex = (currentIndex + 1) % fileURLs.count
+        preparePlayer(at: currentIndex, shouldPlay: shouldPlay)
+    }
+
+    func previous() {
+        guard hasFiles else { return }
+        let shouldPlay = isPlaying
+        currentIndex = (currentIndex - 1 + fileURLs.count) % fileURLs.count
+        preparePlayer(at: currentIndex, shouldPlay: shouldPlay)
+    }
+
+    func setVolume(_ value: Float) {
+        volume = value
+        audioPlayer?.volume = value
+    }
+
+    private func preparePlayer(at index: Int, shouldPlay: Bool) {
+        guard fileURLs.indices.contains(index) else { return }
+        let url = fileURLs[index]
+        do {
+            let player = try AVAudioPlayer(contentsOf: url)
+            player.delegate = self
+            player.volume = volume
+            player.prepareToPlay()
+            audioPlayer = player
+            currentTrackName = url.deletingPathExtension().lastPathComponent
+            if shouldPlay {
+                player.play()
+                isPlaying = true
+            } else {
+                isPlaying = false
+            }
+        } catch {
+            audioPlayer = nil
+            currentTrackName = nil
+            isPlaying = false
+        }
+    }
+}
+
+extension LocalMusicPlayer: AVAudioPlayerDelegate {
+    func audioPlayerDidFinishPlaying(_ player: AVAudioPlayer, successfully flag: Bool) {
+        guard hasFiles else { return }
+        currentIndex = (currentIndex + 1) % fileURLs.count
+        preparePlayer(at: currentIndex, shouldPlay: true)
+    }
+}

--- a/macos/Pomodoro/Pomodoro/MusicPanelView.swift
+++ b/macos/Pomodoro/Pomodoro/MusicPanelView.swift
@@ -8,65 +8,48 @@
 import SwiftUI
 
 struct MusicPanelView: View {
-    @EnvironmentObject private var musicController: MusicController
+    @EnvironmentObject private var localMusicPlayer: LocalMusicPlayer
 
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
-            HStack(spacing: 12) {
-                Button(action: { musicController.previous() }) {
-                    Image(systemName: "backward.fill")
-                }
-                .buttonStyle(.borderless)
-                .disabled(musicController.activeSource == .focusSound)
+            if localMusicPlayer.hasFiles {
+                HStack(spacing: 12) {
+                    Button(action: { localMusicPlayer.previous() }) {
+                        Image(systemName: "backward.fill")
+                    }
+                    .buttonStyle(.borderless)
 
-                Button(action: togglePlayback) {
-                    Image(systemName: musicController.playbackState == .playing ? "pause.fill" : "play.fill")
-                }
-                .buttonStyle(.borderless)
+                    Button(action: togglePlayback) {
+                        Image(systemName: localMusicPlayer.isPlaying ? "pause.fill" : "play.fill")
+                    }
+                    .buttonStyle(.borderless)
 
-                Button(action: { musicController.next() }) {
-                    Image(systemName: "forward.fill")
+                    Button(action: { localMusicPlayer.next() }) {
+                        Image(systemName: "forward.fill")
+                    }
+                    .buttonStyle(.borderless)
                 }
-                .buttonStyle(.borderless)
-                .disabled(musicController.activeSource == .focusSound)
-            }
-            .font(.system(size: 18, weight: .semibold))
+                .font(.system(size: 18, weight: .semibold))
 
-            VStack(alignment: .leading, spacing: 6) {
-                Text("Ambient Sound")
+                Text(localMusicPlayer.currentTrackName ?? "Unknown Track")
                     .font(.system(.subheadline, design: .rounded))
                     .foregroundStyle(.secondary)
-                Picker("Ambient Sound", selection: focusSoundBinding) {
-                    ForEach(FocusSoundType.allCases) { sound in
-                        Text(sound.displayName)
-                            .tag(sound)
-                    }
+            } else {
+                Button("Choose Music") {
+                    localMusicPlayer.loadFiles()
                 }
-                .pickerStyle(.segmented)
+                .buttonStyle(.borderedProminent)
             }
         }
         .padding(20)
         .frame(minWidth: 280)
     }
 
-    private var focusSoundBinding: Binding<FocusSoundType> {
-        Binding(
-            get: { musicController.currentFocusSound },
-            set: { newValue in
-                if newValue == .off {
-                    musicController.stopFocusSound()
-                } else {
-                    musicController.startFocusSound(newValue)
-                }
-            }
-        )
-    }
-
     private func togglePlayback() {
-        if musicController.playbackState == .playing {
-            musicController.pause()
+        if localMusicPlayer.isPlaying {
+            localMusicPlayer.pause()
         } else {
-            musicController.play()
+            localMusicPlayer.play()
         }
     }
 }
@@ -74,5 +57,5 @@ struct MusicPanelView: View {
 #Preview {
     let appState = AppState()
     MusicPanelView()
-        .environmentObject(MusicController(ambientNoiseEngine: appState.ambientNoiseEngine))
+        .environmentObject(appState.localMusicPlayer)
 }

--- a/macos/Pomodoro/Pomodoro/PomodoroApp.swift
+++ b/macos/Pomodoro/Pomodoro/PomodoroApp.swift
@@ -23,6 +23,7 @@ struct PomodoroApp: App {
         WindowGroup {
             ContentView()
                 .environmentObject(appState)
+                .environmentObject(appState.localMusicPlayer)
                 .environmentObject(musicController)
                 .task(id: ObjectIdentifier(appState)) {
                     appDelegate.appState = appState


### PR DESCRIPTION
### Motivation
- Provide a real local music player that plays user-selected audio files (mp3/m4a/wav/aiff) using AVFoundation and that runs independently of system music and window lifecycle.
- Expose simple playback controls to the SwiftUI music panel so users can choose files, play/pause, and navigate tracks during Pomodoro sessions.

### Description
- Add `LocalMusicPlayer.swift` which implements a `LocalMusicPlayer` class using `AVAudioPlayer` and implements `loadFiles()`, `play()`, `pause()`, `next()`, `previous()`, `setVolume(_:)`, `isPlaying`, continuous playback, and automatic next-track behavior via `AVAudioPlayerDelegate`.
- Use `NSOpenPanel` with `allowedContentTypes` set to `.mp3`, `.mpeg4Audio`, `.wav`, and `.aiff` to let users multi-select local audio files and store their URLs in memory.
- Wire the player into the app by adding `let localMusicPlayer: LocalMusicPlayer = LocalMusicPlayer()` to `AppState` and injecting `appState.localMusicPlayer` into windows, previews, and `ContentView`.
- Replace the music UI in `MusicPanelView` to show a `Choose Music` button when no files are loaded and show `Play/Pause`, `Next`, `Previous`, and current track name when files are present, calling the corresponding `LocalMusicPlayer` methods.

### Testing
- No automated tests were run on these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ceee772408323adb753a8ea8f33cf)