### PR TITLE
Add local media player with UI controls and AppState integration

### DIFF
--- a/macos/Pomodoro/Pomodoro.xcodeproj/project.pbxproj
+++ b/macos/Pomodoro/Pomodoro.xcodeproj/project.pbxproj
@@ -24,6 +24,8 @@
 		7C360D902F191F17007313D3 /* MusicController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C360D962F191F17007313D3 /* MusicController.swift */; };
 		7C360D912F191F17007313D3 /* SystemMediaController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C360D972F191F17007313D3 /* SystemMediaController.swift */; };
 		7C360D922F191F17007313D3 /* MusicPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C360D982F191F17007313D3 /* MusicPanelView.swift */; };
+		AB9F279C180740EE9216C649 /* MediaControlBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABFA2AD704BE4758B0A786D8 /* MediaControlBar.swift */; };
+		C9E56B409BCB40FCA8485A09 /* LocalMediaPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05F639B95E5345199E439834 /* LocalMediaPlayer.swift */; };
 		EC7658622FEE47D78BFEA957 /* DailyStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D409152AD794BA998253C35 /* DailyStats.swift */; };
 		E7FB0168DAB22D17FF66223F /* AmbientNoiseEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = C67603580DB6C7C7A08CA894 /* AmbientNoiseEngine.swift */; };
 /* End PBXBuildFile section */
@@ -47,7 +49,9 @@
 		7C360D962F191F17007313D3 /* MusicController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicController.swift; sourceTree = "<group>"; };
 		7C360D972F191F17007313D3 /* SystemMediaController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemMediaController.swift; sourceTree = "<group>"; };
 		7C360D982F191F17007313D3 /* MusicPanelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicPanelView.swift; sourceTree = "<group>"; };
+		05F639B95E5345199E439834 /* LocalMediaPlayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalMediaPlayer.swift; sourceTree = "<group>"; };
 		0D409152AD794BA998253C35 /* DailyStats.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyStats.swift; sourceTree = "<group>"; };
+		ABFA2AD704BE4758B0A786D8 /* MediaControlBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaControlBar.swift; sourceTree = "<group>"; };
 		C67603580DB6C7C7A08CA894 /* AmbientNoiseEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AmbientNoiseEngine.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -129,6 +133,7 @@
 			children = (
 				7C360D532F191F17007313D3 /* ContentView.swift */,
 				7C360D542F191F17007313D3 /* MainWindowView.swift */,
+				ABFA2AD704BE4758B0A786D8 /* MediaControlBar.swift */,
 				7C360D982F191F17007313D3 /* MusicPanelView.swift */,
 			);
 			name = UI;
@@ -137,6 +142,7 @@
 		7C360D9C2F191F17007313D3 /* Music */ = {
 			isa = PBXGroup;
 			children = (
+				05F639B95E5345199E439834 /* LocalMediaPlayer.swift */,
 				7C360D962F191F17007313D3 /* MusicController.swift */,
 				7C360D972F191F17007313D3 /* SystemMediaController.swift */,
 				C67603580DB6C7C7A08CA894 /* AmbientNoiseEngine.swift */,
@@ -226,11 +232,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				7C360D5A2F191F17007313D3 /* ContentView.swift in Sources */,
+				AB9F279C180740EE9216C649 /* MediaControlBar.swift in Sources */,
 				7C360D5B2F191F17007313D3 /* MainWindowView.swift in Sources */,
 				7C360D922F191F17007313D3 /* MusicPanelView.swift in Sources */,
 				7C360D5C2F191F17007313D3 /* PomodoroApp.swift in Sources */,
 				7C360D6B2F191F17007313D3 /* AppDelegate.swift in Sources */,
 				7C360D6A2F191F17007313D3 /* MenuBarController.swift in Sources */,
+				C9E56B409BCB40FCA8485A09 /* LocalMediaPlayer.swift in Sources */,
 				7C360D902F191F17007313D3 /* MusicController.swift in Sources */,
 				7C360D912F191F17007313D3 /* SystemMediaController.swift in Sources */,
 				E7FB0168DAB22D17FF66223F /* AmbientNoiseEngine.swift in Sources */,

--- a/macos/Pomodoro/Pomodoro/AppState.swift
+++ b/macos/Pomodoro/Pomodoro/AppState.swift
@@ -14,6 +14,7 @@ final class AppState: ObservableObject {
     let countdown: CountdownTimerEngine
     let ambientNoiseEngine: AmbientNoiseEngine
     let localMusicPlayer: LocalMusicPlayer = LocalMusicPlayer()
+    @StateObject var mediaPlayer = LocalMediaPlayer()
 
     @Published var durationConfig: DurationConfig {
         didSet {

--- a/macos/Pomodoro/Pomodoro/LocalMediaPlayer.swift
+++ b/macos/Pomodoro/Pomodoro/LocalMediaPlayer.swift
@@ -1,0 +1,116 @@
+//
+//  LocalMediaPlayer.swift
+//  Pomodoro
+//
+//  Created by Zhengyang Hu on 1/15/26.
+//
+
+import AppKit
+import AVFoundation
+import SwiftUI
+import UniformTypeIdentifiers
+
+@MainActor
+final class LocalMediaPlayer: ObservableObject {
+    @Published private(set) var isPlaying = false
+    @Published private(set) var currentTrackTitle: String = "No Track Selected"
+
+    private let player = AVQueuePlayer()
+    private var trackURLs: [URL] = []
+    private var currentIndex = 0
+    private var timeControlObserver: NSKeyValueObservation?
+    private var currentItemObserver: NSKeyValueObservation?
+
+    init() {
+        timeControlObserver = player.observe(\.timeControlStatus, options: [.initial, .new]) { [weak self] player, _ in
+            Task { @MainActor in
+                self?.isPlaying = player.timeControlStatus == .playing
+            }
+        }
+
+        currentItemObserver = player.observe(\.currentItem, options: [.initial, .new]) { [weak self] _, _ in
+            Task { @MainActor in
+                self?.syncCurrentTrackTitle()
+            }
+        }
+    }
+
+    func loadLocalFiles() {
+        let panel = NSOpenPanel()
+        panel.canChooseFiles = true
+        panel.canChooseDirectories = false
+        panel.allowsMultipleSelection = true
+        panel.allowedContentTypes = [.mp3, .mpeg4Audio, .wav, .aiff]
+
+        guard panel.runModal() == .OK else { return }
+        trackURLs = panel.urls
+        currentIndex = 0
+        rebuildQueue(startingAt: currentIndex)
+    }
+
+    func play() {
+        if player.items().isEmpty {
+            rebuildQueue(startingAt: currentIndex)
+        }
+        player.play()
+    }
+
+    func pause() {
+        player.pause()
+    }
+
+    func togglePlayPause() {
+        if isPlaying {
+            pause()
+        } else {
+            play()
+        }
+    }
+
+    func nextTrack() {
+        guard !trackURLs.isEmpty else { return }
+        let shouldPlay = isPlaying
+        currentIndex = (currentIndex + 1) % trackURLs.count
+        rebuildQueue(startingAt: currentIndex)
+        if shouldPlay {
+            player.play()
+        }
+    }
+
+    func previousTrack() {
+        guard !trackURLs.isEmpty else { return }
+        let shouldPlay = isPlaying
+        currentIndex = (currentIndex - 1 + trackURLs.count) % trackURLs.count
+        rebuildQueue(startingAt: currentIndex)
+        if shouldPlay {
+            player.play()
+        }
+    }
+
+    private func rebuildQueue(startingAt index: Int) {
+        player.removeAllItems()
+        guard trackURLs.indices.contains(index) else {
+            currentTrackTitle = "No Track Selected"
+            return
+        }
+
+        let items = trackURLs[index...].map { AVPlayerItem(url: $0) }
+        for item in items {
+            player.insert(item, after: nil)
+        }
+        syncCurrentTrackTitle()
+    }
+
+    private func syncCurrentTrackTitle() {
+        guard let urlAsset = player.currentItem?.asset as? AVURLAsset else {
+            currentTrackTitle = "No Track Selected"
+            return
+        }
+
+        let url = urlAsset.url
+        currentTrackTitle = url.deletingPathExtension().lastPathComponent
+        if let index = trackURLs.firstIndex(of: url) {
+            currentIndex = index
+        }
+    }
+}

--- a/macos/Pomodoro/Pomodoro/MainWindowView.swift
+++ b/macos/Pomodoro/Pomodoro/MainWindowView.swift
@@ -168,6 +168,9 @@ struct MainWindowView: View {
                     .foregroundStyle(.secondary)
                 summarySection
             }
+
+            MediaControlBar()
+                .environmentObject(appState.mediaPlayer)
         }
         .padding()
         .frame(minWidth: 360)

--- a/macos/Pomodoro/Pomodoro/MediaControlBar.swift
+++ b/macos/Pomodoro/Pomodoro/MediaControlBar.swift
@@ -1,0 +1,73 @@
+//
+//  MediaControlBar.swift
+//  Pomodoro
+//
+//  Created by Zhengyang Hu on 1/15/26.
+//
+
+import SwiftUI
+
+struct MediaControlBar: View {
+    @EnvironmentObject private var mediaPlayer: LocalMediaPlayer
+
+    var body: some View {
+        HStack(spacing: 12) {
+            ZStack {
+                Circle()
+                    .fill(.quaternary)
+                Image(systemName: "music.note")
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundStyle(.secondary)
+            }
+            .frame(width: 32, height: 32)
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(mediaPlayer.currentTrackTitle)
+                    .font(.system(.subheadline, design: .rounded))
+                    .foregroundStyle(.primary)
+                    .lineLimit(1)
+
+                Button("Choose Music") {
+                    mediaPlayer.loadLocalFiles()
+                }
+                .buttonStyle(.link)
+                .font(.system(.caption, design: .rounded))
+            }
+
+            Spacer(minLength: 8)
+
+            Button {
+                mediaPlayer.togglePlayPause()
+            } label: {
+                Image(systemName: mediaPlayer.isPlaying ? "pause.fill" : "play.fill")
+                    .font(.system(size: 14, weight: .semibold))
+                    .frame(width: 32, height: 32)
+            }
+            .buttonStyle(.plain)
+            .background(Circle().fill(.ultraThinMaterial))
+
+            Button {
+                mediaPlayer.nextTrack()
+            } label: {
+                Image(systemName: "forward.fill")
+                    .font(.system(size: 14, weight: .semibold))
+                    .frame(width: 32, height: 32)
+            }
+            .buttonStyle(.plain)
+            .background(Circle().fill(.ultraThinMaterial))
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 10)
+        .background(Capsule().fill(.ultraThinMaterial))
+        .overlay(
+            Capsule()
+                .strokeBorder(.white.opacity(0.2))
+        )
+    }
+}
+
+#Preview {
+    MediaControlBar()
+        .environmentObject(LocalMediaPlayer())
+        .padding()
+}


### PR DESCRIPTION
### Motivation
- Provide a real, local audio player so users can choose and play local audio files from the main window independent of Pomodoro logic.
- Surface simple playback controls in the UI so users can control playback without opening separate panels.

### Description
- Add `LocalMediaPlayer` (`LocalMediaPlayer.swift`) as an `ObservableObject` backed by `AVQueuePlayer` with methods `loadLocalFiles()`, `play()`, `pause()`, `togglePlayPause()`, `nextTrack()`, and `previousTrack()`, and published properties `isPlaying` and `currentTrackTitle`.
- Implement file selection using `NSOpenPanel` that accepts `mp3`, `m4a`, `wav`, and `aiff` files and builds an `AVPlayerItem` queue so audio is audible when played.
- Add `MediaControlBar` (`MediaControlBar.swift`) SwiftUI view presenting a pill-shaped control bar with artwork placeholder, track title, a `Choose Music` link, play/pause button, and next button; buttons call the `LocalMediaPlayer` methods directly.
- Wire the player into the app lifecycle by adding `@StateObject var mediaPlayer = LocalMediaPlayer()` to `AppState.swift` and mounting `MediaControlBar()` in `MainWindowView.swift` below the Pomodoro/Countdown sections while injecting the `mediaPlayer` via `environmentObject`.
- Register the new source files in the Xcode project file so they are compiled and visible in the app UI.

### Testing
- No automated tests were run as part of this change.
- Manual validation checklist intended for runtime: file picker opens via `Choose Music`, files load, pressing `Play` produces audible sound, `Play/Pause` toggles, and `currentTrackTitle` updates when tracks change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696cf5ca1c748323be97d68766d52ca5)