### PR TITLE
Add system media controller and unified media routing

### DIFF
--- a/macos/PomodoroApp/ActiveMediaSource.swift
+++ b/macos/PomodoroApp/ActiveMediaSource.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+enum ActiveMediaSource: String {
+    case system
+    case local
+    case none
+}

--- a/macos/PomodoroApp/AppState.swift
+++ b/macos/PomodoroApp/AppState.swift
@@ -1,16 +1,143 @@
+import Combine
 import SwiftUI
 
-final class AppState: ObservableObject {
+@MainActor
+final class AppState: ObservableObject, DynamicProperty {
     @Published var currentMode: PomodoroMode = .idle
     @Published var completedWorkSessions: Int = 0
     @Published var workDuration: Int = 25 * 60
     @Published var breakDuration: Int = 5 * 60
     @Published var longBreakDuration: Int = 15 * 60
-    let mediaPlayer = LocalMediaPlayer()
+    @Published var activeMediaSource: ActiveMediaSource = .none
+    @Published var lastActiveMediaSource: ActiveMediaSource = .none
+    @StateObject var systemMedia = SystemMediaController()
+    @StateObject var localMedia = LocalMediaPlayer()
 
-    init() {}
+    private let lastActiveSourceKey = "lastActiveMediaSource"
+    private var cancellables = Set<AnyCancellable>()
+    private var shouldResumeLocalAfterSystem = false
+
+    init() {
+        restoreLastActiveMediaSource()
+        bindMediaUpdates()
+        updateActiveMediaSource()
+    }
 
     func setWorkDuration(minutes: Int) {
         workDuration = minutes * 60
+    }
+
+    func update() {}
+
+    func togglePlayPause() {
+        switch activeMediaSource {
+        case .system:
+            systemMedia.togglePlayPause()
+        case .local:
+            localMedia.togglePlayPause()
+        case .none:
+            break
+        }
+    }
+
+    func nextTrack() {
+        switch activeMediaSource {
+        case .system:
+            systemMedia.nextTrack()
+        case .local:
+            localMedia.next()
+        case .none:
+            break
+        }
+    }
+
+    func previousTrack() {
+        switch activeMediaSource {
+        case .system:
+            systemMedia.previousTrack()
+        case .local:
+            localMedia.previous()
+        case .none:
+            break
+        }
+    }
+
+    private func bindMediaUpdates() {
+        systemMedia.$isPlaying
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] isPlaying in
+                self?.handleSystemPlaybackChange(isPlaying: isPlaying)
+            }
+            .store(in: &cancellables)
+
+        localMedia.$hasLoaded
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.updateActiveMediaSource()
+            }
+            .store(in: &cancellables)
+
+        localMedia.$isPlaying
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] isPlaying in
+                self?.handleLocalPlaybackChange(isPlaying: isPlaying)
+            }
+            .store(in: &cancellables)
+    }
+
+    private func handleSystemPlaybackChange(isPlaying: Bool) {
+        if isPlaying {
+            if localMedia.isPlaying {
+                shouldResumeLocalAfterSystem = true
+                localMedia.pause()
+            } else {
+                shouldResumeLocalAfterSystem = false
+            }
+            setActiveMediaSource(.system)
+        } else if activeMediaSource == .system {
+            if localMedia.hasLoaded {
+                setActiveMediaSource(.local)
+                if shouldResumeLocalAfterSystem {
+                    localMedia.play()
+                }
+            } else {
+                activeMediaSource = .none
+            }
+        } else {
+            updateActiveMediaSource()
+        }
+    }
+
+    private func handleLocalPlaybackChange(isPlaying: Bool) {
+        guard activeMediaSource != .system else { return }
+        if isPlaying {
+            setActiveMediaSource(.local)
+        } else {
+            updateActiveMediaSource()
+        }
+    }
+
+    private func updateActiveMediaSource() {
+        if systemMedia.isPlaying {
+            setActiveMediaSource(.system)
+        } else if localMedia.hasLoaded {
+            setActiveMediaSource(.local)
+        } else {
+            activeMediaSource = .none
+        }
+    }
+
+    private func setActiveMediaSource(_ source: ActiveMediaSource) {
+        activeMediaSource = source
+        guard source != .none else { return }
+        lastActiveMediaSource = source
+        UserDefaults.standard.set(source.rawValue, forKey: lastActiveSourceKey)
+    }
+
+    private func restoreLastActiveMediaSource() {
+        if let storedValue = UserDefaults.standard.string(forKey: lastActiveSourceKey),
+           let restoredSource = ActiveMediaSource(rawValue: storedValue) {
+            lastActiveMediaSource = restoredSource
+        }
     }
 }

--- a/macos/PomodoroApp/LocalMediaPlayer.swift
+++ b/macos/PomodoroApp/LocalMediaPlayer.swift
@@ -7,6 +7,7 @@ final class LocalMediaPlayer: NSObject, ObservableObject {
     @Published private(set) var isPlaying: Bool = false
     @Published private(set) var currentTrackTitle: String = "No Track Selected"
     @Published private(set) var currentArtwork: NSImage?
+    @Published private(set) var hasLoaded: Bool = false
 
     private let player = AVQueuePlayer()
     private var currentItems: [AVPlayerItem] = []
@@ -86,6 +87,7 @@ final class LocalMediaPlayer: NSObject, ObservableObject {
         currentIndex = 0
         rebuildQueue(startingAt: 0)
         updateNowPlaying(from: items[0])
+        hasLoaded = true
     }
 
     private func rebuildQueue(startingAt index: Int) {

--- a/macos/PomodoroApp/MainWindowView.swift
+++ b/macos/PomodoroApp/MainWindowView.swift
@@ -10,10 +10,10 @@ struct MainWindowView: View {
             Text("Ready to focus.")
                 .foregroundStyle(.secondary)
             Button("Choose Music") {
-                appState.mediaPlayer.loadFiles()
+                appState.localMedia.loadFiles()
             }
             .buttonStyle(.bordered)
-            MediaControlBar(player: appState.mediaPlayer)
+            MediaControlBar()
             DebugStateView()
         }
         .frame(minWidth: 480, minHeight: 320)

--- a/macos/PomodoroApp/MediaControlBar.swift
+++ b/macos/PomodoroApp/MediaControlBar.swift
@@ -1,12 +1,56 @@
 import SwiftUI
 
 struct MediaControlBar: View {
-    @ObservedObject var player: LocalMediaPlayer
+    @EnvironmentObject private var appState: AppState
+
+    private var isPlaying: Bool {
+        switch appState.activeMediaSource {
+        case .system:
+            return appState.systemMedia.isPlaying
+        case .local:
+            return appState.localMedia.isPlaying
+        case .none:
+            return false
+        }
+    }
+
+    private var trackTitle: String {
+        switch appState.activeMediaSource {
+        case .system:
+            return appState.systemMedia.trackTitle
+        case .local:
+            return appState.localMedia.currentTrackTitle
+        case .none:
+            return appState.localMedia.currentTrackTitle
+        }
+    }
+
+    private var sourceLabel: String {
+        switch appState.activeMediaSource {
+        case .system:
+            return "System Audio"
+        case .local:
+            return "Local Audio"
+        case .none:
+            return "Local Audio"
+        }
+    }
+
+    private var artwork: NSImage? {
+        switch appState.activeMediaSource {
+        case .system:
+            return appState.systemMedia.currentArtwork
+        case .local:
+            return appState.localMedia.currentArtwork
+        case .none:
+            return appState.localMedia.currentArtwork
+        }
+    }
 
     var body: some View {
         HStack(spacing: 12) {
             Group {
-                if let artwork = player.currentArtwork {
+                if let artwork {
                     Image(nsImage: artwork)
                         .resizable()
                         .scaledToFill()
@@ -22,19 +66,29 @@ struct MediaControlBar: View {
             .frame(width: 44, height: 44)
             .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
 
-            Text(player.currentTrackTitle)
-                .font(.headline)
-                .lineLimit(1)
-                .truncationMode(.tail)
-                .frame(maxWidth: .infinity, alignment: .leading)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(trackTitle)
+                    .font(.headline)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+                Text(sourceLabel)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
 
             HStack(spacing: 12) {
-                Button(action: player.togglePlayPause) {
-                    Image(systemName: player.isPlaying ? "pause.fill" : "play.fill")
+                Button(action: appState.previousTrack) {
+                    Image(systemName: "backward.fill")
                 }
                 .buttonStyle(.plain)
 
-                Button(action: player.next) {
+                Button(action: appState.togglePlayPause) {
+                    Image(systemName: isPlaying ? "pause.fill" : "play.fill")
+                }
+                .buttonStyle(.plain)
+
+                Button(action: appState.nextTrack) {
                     Image(systemName: "forward.fill")
                 }
                 .buttonStyle(.plain)
@@ -55,6 +109,7 @@ struct MediaControlBar: View {
 }
 
 #Preview {
-    MediaControlBar(player: LocalMediaPlayer())
+    MediaControlBar()
+        .environmentObject(AppState())
         .padding()
 }

--- a/macos/PomodoroApp/SystemMediaController.swift
+++ b/macos/PomodoroApp/SystemMediaController.swift
@@ -1,0 +1,103 @@
+import AppKit
+import MediaPlayer
+
+@MainActor
+final class SystemMediaController: ObservableObject {
+    @Published private(set) var trackTitle: String = "No System Audio"
+    @Published private(set) var artistName: String?
+    @Published private(set) var playbackState: MPNowPlayingPlaybackState = .stopped
+    @Published private(set) var isPlaying: Bool = false
+    @Published private(set) var currentArtwork: NSImage?
+
+    private let commandCenter = MPRemoteCommandCenter.shared()
+    private var observers: [NSObjectProtocol] = []
+    private var refreshTimer: Timer?
+
+    init(notificationCenter: NotificationCenter = .default) {
+        observers.append(notificationCenter.addObserver(
+            forName: .MPNowPlayingInfoCenterNowPlayingInfoDidChange,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            self?.refreshNowPlayingInfo()
+        })
+
+        observers.append(notificationCenter.addObserver(
+            forName: .MPNowPlayingInfoCenterPlaybackStateDidChange,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            self?.refreshPlaybackState()
+        })
+
+        refreshTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
+            self?.refreshNowPlayingInfo()
+        }
+
+        refreshNowPlayingInfo()
+    }
+
+    deinit {
+        observers.forEach(NotificationCenter.default.removeObserver)
+        refreshTimer?.invalidate()
+    }
+
+    func play() {
+        sendCommand(commandCenter.playCommand)
+    }
+
+    func pause() {
+        sendCommand(commandCenter.pauseCommand)
+    }
+
+    func togglePlayPause() {
+        isPlaying ? pause() : play()
+    }
+
+    func nextTrack() {
+        sendCommand(commandCenter.nextTrackCommand)
+    }
+
+    func previousTrack() {
+        sendCommand(commandCenter.previousTrackCommand)
+    }
+
+    private func refreshNowPlayingInfo() {
+        let infoCenter = MPNowPlayingInfoCenter.default()
+        let info = infoCenter.nowPlayingInfo ?? [:]
+
+        let title = info[MPMediaItemPropertyTitle] as? String
+        let artist = info[MPMediaItemPropertyArtist] as? String
+        let artwork = info[MPMediaItemPropertyArtwork] as? MPMediaItemArtwork
+        let artworkImage = artwork?.image(at: NSSize(width: 64, height: 64))
+
+        trackTitle = title ?? (info.isEmpty ? "No System Audio" : "Unknown Title")
+        artistName = artist
+        currentArtwork = artworkImage
+
+        refreshPlaybackState()
+    }
+
+    private func refreshPlaybackState() {
+        let infoCenter = MPNowPlayingInfoCenter.default()
+        let info = infoCenter.nowPlayingInfo ?? [:]
+        let rate = info[MPNowPlayingInfoPropertyPlaybackRate] as? Double ?? 0
+
+        if infoCenter.playbackState != .unknown {
+            playbackState = infoCenter.playbackState
+        } else if rate > 0 {
+            playbackState = .playing
+        } else if info.isEmpty {
+            playbackState = .stopped
+        } else {
+            playbackState = .paused
+        }
+
+        isPlaying = playbackState == .playing
+    }
+
+    private func sendCommand(_ command: MPRemoteCommand) {
+        guard command.isEnabled else { return }
+        command.sendAction()
+    }
+}


### PR DESCRIPTION
### Motivation
- Detect and control system-wide media (Apple Music, Spotify, browsers, etc.) and gracefully fall back to the existing local player while preserving existing local playback behavior.
- Unify media state so the UI and controls route to the active source and remember the last source across app launches.

### Description
- Add `ActiveMediaSource` enum and a new `SystemMediaController` (`SystemMediaController.swift`) as an `ObservableObject` that observes `MPNowPlayingInfoCenter` and exposes play/pause/next/previous via `MPRemoteCommandCenter` and periodic refreshes of now-playing info.
- Extend `AppState` to own `@StateObject var systemMedia` and `@StateObject var localMedia`, introduce `@Published var activeMediaSource` and `lastActiveMediaSource`, persist `lastActiveMediaSource` to `UserDefaults`, and implement routing methods `togglePlayPause`, `nextTrack`, and `previousTrack` and switching logic that prefers system playback and falls back to local playback.
- Update `LocalMediaPlayer` to expose `hasLoaded` so the app can determine when local tracks are available without breaking existing playback behavior.
- Update UI: `MediaControlBar` now reads from `AppState` (`@EnvironmentObject`) to show the active track title, artwork, and a subtle `System Audio` / `Local Audio` label and routes control buttons through `AppState`; `MainWindowView` now calls `appState.localMedia.loadFiles()`.

### Testing
- No automated tests were executed for these macOS UI and system-integration changes in this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696cf9cb3d808323a084ed25c463ffc9)