### PR TITLE
Implement user-driven system media control

### DIFF
--- a/macos/PomodoroApp/MediaControlBar.swift
+++ b/macos/PomodoroApp/MediaControlBar.swift
@@ -28,7 +28,7 @@ struct MediaControlBar: View {
     private var sourceLabel: String {
         switch appState.activeMediaSource {
         case .system:
-            return "System Audio"
+            return appState.systemMedia.isSessionActive ? "System Audio" : "System Audio (Inactive)"
         case .local:
             return "Local Audio"
         case .none:
@@ -39,7 +39,7 @@ struct MediaControlBar: View {
     private var artwork: NSImage? {
         switch appState.activeMediaSource {
         case .system:
-            return appState.systemMedia.currentArtwork
+            return appState.systemMedia.artwork
         case .local:
             return appState.localMedia.currentArtwork
         case .none:
@@ -73,7 +73,7 @@ struct MediaControlBar: View {
                     .truncationMode(.tail)
                 Text(sourceLabel)
                     .font(.caption)
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(appState.activeMediaSource == .system && !appState.systemMedia.isSessionActive ? .orange : .secondary)
             }
             .frame(maxWidth: .infinity, alignment: .leading)
 


### PR DESCRIPTION
### Motivation
- Prevent passive system media detection and ensure media control and metadata exposure only happen following explicit user actions, while restoring the last known metadata on launch.
- Use only public APIs (`MPRemoteCommandCenter`, `MPNowPlayingInfoCenter`, `AVAudioSession`) to remain App Store / TestFlight compliant.

### Description
- Reworked `SystemMediaController` to expose `isSessionActive`, `isPlaying`, `title`, `artist`, `artwork`, and `lastUpdatedAt`, and to activate the audio session only on user-initiated `play` actions via `AVAudioSession`.
- Removed background observers/polling for passive detection and updated `refreshNowPlayingInfo()` to read `MPNowPlayingInfoCenter` only after user-triggered commands and to cache metadata to `UserDefaults` and restore on init.
- Updated `AppState` bindings to observe `systemMedia.$isSessionActive` and added `ensureActiveSourceBeforeControl()` to avoid auto-selecting system media without user intent.
- Updated `MediaControlBar` to use the new `artwork` property and clearly indicate when system media is inactive with a different label and visual style.

### Testing
- No automated tests were run on these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696dc915ce588323972347dcdf832738)