### PR TITLE
Add explicit "Connect to System Media" flow and UI for inactive system media

### DIFF
--- a/macos/PomodoroApp/AppState.swift
+++ b/macos/PomodoroApp/AppState.swift
@@ -65,6 +65,11 @@ final class AppState: ObservableObject, DynamicProperty {
         }
     }
 
+    func connectSystemMedia() {
+        setActiveMediaSource(.system)
+        systemMedia.connect()
+    }
+
     private func bindMediaUpdates() {
         systemMedia.$isSessionActive
             .receive(on: DispatchQueue.main)

--- a/macos/PomodoroApp/MediaControlBar.swift
+++ b/macos/PomodoroApp/MediaControlBar.swift
@@ -28,7 +28,7 @@ struct MediaControlBar: View {
     private var sourceLabel: String {
         switch appState.activeMediaSource {
         case .system:
-            return appState.systemMedia.isSessionActive ? "System Audio" : "System Audio (Inactive)"
+            return appState.systemMedia.isSessionActive ? "System Media" : "System Media (Inactive)"
         case .local:
             return "Local Audio"
         case .none:
@@ -71,27 +71,39 @@ struct MediaControlBar: View {
                     .font(.headline)
                     .lineLimit(1)
                     .truncationMode(.tail)
-                Text(sourceLabel)
-                    .font(.caption)
-                    .foregroundStyle(appState.activeMediaSource == .system && !appState.systemMedia.isSessionActive ? .orange : .secondary)
+                HStack(spacing: 6) {
+                    Circle()
+                        .fill(statusColor)
+                        .frame(width: 6, height: 6)
+                    Text(sourceLabel)
+                        .font(.caption)
+                }
+                .foregroundStyle(appState.activeMediaSource == .system && !appState.systemMedia.isSessionActive ? .orange : .secondary)
             }
             .frame(maxWidth: .infinity, alignment: .leading)
 
-            HStack(spacing: 12) {
-                Button(action: appState.previousTrack) {
-                    Image(systemName: "backward.fill")
+            if shouldShowConnectButton {
+                Button(action: appState.connectSystemMedia) {
+                    Text("▶︎ Connect to System Media")
                 }
-                .buttonStyle(.plain)
+                .buttonStyle(.borderedProminent)
+            } else {
+                HStack(spacing: 12) {
+                    Button(action: appState.previousTrack) {
+                        Image(systemName: "backward.fill")
+                    }
+                    .buttonStyle(.plain)
 
-                Button(action: appState.togglePlayPause) {
-                    Image(systemName: isPlaying ? "pause.fill" : "play.fill")
-                }
-                .buttonStyle(.plain)
+                    Button(action: appState.togglePlayPause) {
+                        Image(systemName: isPlaying ? "pause.fill" : "play.fill")
+                    }
+                    .buttonStyle(.plain)
 
-                Button(action: appState.nextTrack) {
-                    Image(systemName: "forward.fill")
+                    Button(action: appState.nextTrack) {
+                        Image(systemName: "forward.fill")
+                    }
+                    .buttonStyle(.plain)
                 }
-                .buttonStyle(.plain)
             }
         }
         .padding(.horizontal, 16)
@@ -105,6 +117,21 @@ struct MediaControlBar: View {
                 .strokeBorder(Color.primary.opacity(0.08), lineWidth: 1)
         )
         .shadow(color: Color.black.opacity(0.12), radius: 12, x: 0, y: 6)
+    }
+
+    private var shouldShowConnectButton: Bool {
+        appState.activeMediaSource == .system && !appState.systemMedia.isSessionActive
+    }
+
+    private var statusColor: Color {
+        switch appState.activeMediaSource {
+        case .system:
+            return appState.systemMedia.isSessionActive ? .green : .orange
+        case .local:
+            return .blue
+        case .none:
+            return .secondary
+        }
     }
 }
 


### PR DESCRIPTION
### Motivation
- Prevent automatic system media discovery and only surface now-playing metadata after an explicit user action to make the integration feel intentional and TestFlight-safe. 
- Ensure system controls use `MPRemoteCommandCenter` and `MPNowPlayingInfoCenter` only after an audio session is activated. 
- Provide clear UI affordance for connecting to system media and indicate active vs inactive state.

### Description
- Add a `connect()` method on `SystemMediaController` and gate now-playing reads behind `activateAudioSessionIfNeeded()` so `MPNowPlayingInfoCenter` is only consulted after session activation, and change activation method to return a `Bool` (`activateAudioSessionIfNeeded()`).
- Replace the default title from `"No Track Selected"` to `"System Media (Inactive)"` and keep metadata caching/restore in place via existing `restoreCachedMetadata()`/`cacheMetadata()` logic. 
- Add `connectSystemMedia()` to `AppState` to set the active source and call the controller `connect()` action. 
- Update `MediaControlBar` UI to show `"System Media"`/`"System Media (Inactive)"`, add a colored status dot, and display a prominent `▶︎ Connect to System Media` button when the app is set to the system source but the session is inactive; normal playback controls are shown after connection.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696de6ba38708323844b5699ce28d86a)