### PR TITLE
Detect and control system Now Playing sessions (MediaPlayer integration)

### DIFF
--- a/macos/PomodoroApp/AppState.swift
+++ b/macos/PomodoroApp/AppState.swift
@@ -21,6 +21,7 @@ final class AppState: ObservableObject, DynamicProperty {
         restoreLastActiveMediaSource()
         bindMediaUpdates()
         updateActiveMediaSource()
+        systemMedia.connect()
     }
 
     func setWorkDuration(minutes: Int) {
@@ -144,7 +145,7 @@ final class AppState: ObservableObject, DynamicProperty {
         } else if localMedia.hasLoaded {
             setActiveMediaSource(.local)
         } else {
-            activeMediaSource = lastActiveMediaSource
+            activeMediaSource = .none
         }
     }
 

--- a/macos/PomodoroApp/MainWindowView.swift
+++ b/macos/PomodoroApp/MainWindowView.swift
@@ -9,10 +9,6 @@ struct MainWindowView: View {
                 .font(.largeTitle)
             Text("Ready to focus.")
                 .foregroundStyle(.secondary)
-            Button("Choose Music") {
-                appState.localMedia.loadFiles()
-            }
-            .buttonStyle(.bordered)
             MediaControlBar()
             DebugStateView()
         }

--- a/macos/PomodoroApp/MediaControlBar.swift
+++ b/macos/PomodoroApp/MediaControlBar.swift
@@ -21,18 +21,18 @@ struct MediaControlBar: View {
         case .local:
             return appState.localMedia.currentTrackTitle
         case .none:
-            return appState.localMedia.currentTrackTitle
+            return "Nothing Playing"
         }
     }
 
-    private var sourceLabel: String {
+    private var artistLabel: String {
         switch appState.activeMediaSource {
         case .system:
-            return appState.systemMedia.isSessionActive ? "System Media" : "System Media (Inactive)"
+            return appState.systemMedia.artist ?? "Unknown Artist"
         case .local:
             return "Local Audio"
         case .none:
-            return "Local Audio"
+            return "Play audio in Music, Spotify, or your browser."
         }
     }
 
@@ -43,7 +43,7 @@ struct MediaControlBar: View {
         case .local:
             return appState.localMedia.currentArtwork
         case .none:
-            return appState.localMedia.currentArtwork
+            return nil
         }
     }
 
@@ -71,40 +71,32 @@ struct MediaControlBar: View {
                     .font(.headline)
                     .lineLimit(1)
                     .truncationMode(.tail)
-                HStack(spacing: 6) {
-                    Circle()
-                        .fill(statusColor)
-                        .frame(width: 6, height: 6)
-                    Text(sourceLabel)
-                        .font(.caption)
-                }
-                .foregroundStyle(appState.activeMediaSource == .system && !appState.systemMedia.isSessionActive ? .orange : .secondary)
+                Text(artistLabel)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
             }
             .frame(maxWidth: .infinity, alignment: .leading)
 
-            if shouldShowConnectButton {
-                Button(action: appState.connectSystemMedia) {
-                    Text("▶︎ Connect to System Media")
+            HStack(spacing: 12) {
+                Button(action: appState.previousTrack) {
+                    Image(systemName: "backward.fill")
                 }
-                .buttonStyle(.borderedProminent)
-            } else {
-                HStack(spacing: 12) {
-                    Button(action: appState.previousTrack) {
-                        Image(systemName: "backward.fill")
-                    }
-                    .buttonStyle(.plain)
+                .buttonStyle(.plain)
+                .disabled(!controlsEnabled)
 
-                    Button(action: appState.togglePlayPause) {
-                        Image(systemName: isPlaying ? "pause.fill" : "play.fill")
-                    }
-                    .buttonStyle(.plain)
-
-                    Button(action: appState.nextTrack) {
-                        Image(systemName: "forward.fill")
-                    }
-                    .buttonStyle(.plain)
+                Button(action: appState.togglePlayPause) {
+                    Image(systemName: isPlaying ? "pause.fill" : "play.fill")
                 }
+                .buttonStyle(.plain)
+                .disabled(!controlsEnabled)
+
+                Button(action: appState.nextTrack) {
+                    Image(systemName: "forward.fill")
+                }
+                .buttonStyle(.plain)
+                .disabled(!controlsEnabled)
             }
+            .foregroundStyle(controlsEnabled ? .primary : .secondary)
         }
         .padding(.horizontal, 16)
         .padding(.vertical, 10)
@@ -119,18 +111,14 @@ struct MediaControlBar: View {
         .shadow(color: Color.black.opacity(0.12), radius: 12, x: 0, y: 6)
     }
 
-    private var shouldShowConnectButton: Bool {
-        appState.activeMediaSource == .system && !appState.systemMedia.isSessionActive
-    }
-
-    private var statusColor: Color {
+    private var controlsEnabled: Bool {
         switch appState.activeMediaSource {
         case .system:
-            return appState.systemMedia.isSessionActive ? .green : .orange
+            return appState.systemMedia.isSessionActive
         case .local:
-            return .blue
+            return appState.localMedia.hasLoaded
         case .none:
-            return .secondary
+            return false
         }
     }
 }


### PR DESCRIPTION
### Motivation
- Surface and control the system "Now Playing" session (like Control Center) so the app can detect and control playback from Spotify, Music, browsers, etc.
- Rely on `MediaPlayer` (`MPNowPlayingInfoCenter` / `MPRemoteCommandCenter`) without creating or activating an audio session or modifying the ambient noise engine.
- Replace the local "Choose Music" affordance with a Control Center–style live media display when system media is available.

### Description
- Update `SystemMediaController` to observe `MPNowPlayingInfoCenterNowPlayingInfoDidChange` and `MPNowPlayingInfoCenterPlaybackStateDidChange`, refresh metadata on changes, and cache/clear metadata; remove AVAudioSession activation and the `AVFoundation` import (file: `macos/PomodoroApp/SystemMediaController.swift`).
- Default system title to "Nothing Playing", set `isSessionActive` based on now-playing info/playback state, clear UI fields when no session exists, and prefer album artist when available (file: `macos/PomodoroApp/SystemMediaController.swift`).
- Call `systemMedia.connect()` at app state initialization and ensure `activeMediaSource` falls back to `.none` when nothing is loaded (file: `macos/PomodoroApp/AppState.swift`).
- Remove the former "Choose Music" button from the main window and update `MediaControlBar` to show live track/title/artist/artwork or a friendly "Nothing Playing" message, disable transport controls when no session is active, and simplify the UI to match Control Center–style behavior (files: `macos/PomodoroApp/MainWindowView.swift`, `macos/PomodoroApp/MediaControlBar.swift`).

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696de93dca04832392700286721aee9e)