### PR TITLE
Provider-based Now Playing: Apple Music & Spotify with Router and UI

### DIFF
--- a/macos/Pomodoro/Pomodoro/AppDelegate.swift
+++ b/macos/Pomodoro/Pomodoro/AppDelegate.swift
@@ -10,11 +10,9 @@ import SwiftUI
 
 final class AppDelegate: NSObject, NSApplicationDelegate {
     private weak var mainWindow: NSWindow?
-    private weak var musicWindow: NSWindow?
     private var appStateConfigured = false
     private var menuBarController: MenuBarController?
     private let mainWindowFrameAutosaveName = "PomodoroMainWindowFrame"
-    private let musicWindowFrameAutosaveName = "PomodoroMusicWindowFrame"
 
     var appState: AppState? {
         didSet {
@@ -61,38 +59,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         window.contentViewController = NSHostingController(
             rootView: ContentView()
                 .environmentObject(appState)
-                .environmentObject(appState.localMusicPlayer)
+                .environmentObject(appState.nowPlayingRouter)
                 .environmentObject(musicController)
         )
         configureWindowPersistence(window)
         window.makeKeyAndOrderFront(nil)
         focus(window: window)
         mainWindow = window
-    }
-
-    func openMusicPanel() {
-        guard let appState else { return }
-
-        if let window = musicWindow {
-            focus(window: window)
-            return
-        }
-
-        let window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 320, height: 220),
-            styleMask: [.titled, .closable],
-            backing: .buffered,
-            defer: false
-        )
-        window.title = "Music"
-        window.isReleasedWhenClosed = true
-        window.contentViewController = NSHostingController(
-            rootView: MusicPanelView().environmentObject(appState.localMusicPlayer)
-        )
-        configureWindowPersistence(window, autosaveName: musicWindowFrameAutosaveName)
-        window.makeKeyAndOrderFront(nil)
-        focus(window: window)
-        musicWindow = window
     }
 
     private func quitApp() {
@@ -137,9 +110,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             musicController: musicController,
             openMainWindow: { [weak self] in
                 self?.openMainWindow()
-            },
-            openMusicPanel: { [weak self] in
-                self?.openMusicPanel()
             },
             quitApp: { [weak self] in
                 self?.quitApp()

--- a/macos/Pomodoro/Pomodoro/AppState.swift
+++ b/macos/Pomodoro/Pomodoro/AppState.swift
@@ -13,8 +13,7 @@ final class AppState: ObservableObject {
     let pomodoro: PomodoroTimerEngine
     let countdown: CountdownTimerEngine
     let ambientNoiseEngine: AmbientNoiseEngine
-    let localMusicPlayer: LocalMusicPlayer = LocalMusicPlayer()
-    @StateObject var mediaPlayer = LocalMediaPlayer()
+    let nowPlayingRouter: NowPlayingRouter
 
     @Published var durationConfig: DurationConfig {
         didSet {
@@ -65,6 +64,7 @@ final class AppState: ObservableObject {
         self.pomodoro = pomodoro
         self.countdown = countdown
         self.ambientNoiseEngine = ambientNoiseEngine
+        self.nowPlayingRouter = NowPlayingRouter()
         self.durationConfig = durationConfig
         self.presetSelection = PresetSelection.selection(for: durationConfig)
         self.pomodoroMode = pomodoro.mode

--- a/macos/Pomodoro/Pomodoro/AppleMusicProvider.swift
+++ b/macos/Pomodoro/Pomodoro/AppleMusicProvider.swift
@@ -1,0 +1,87 @@
+//
+//  AppleMusicProvider.swift
+//  Pomodoro
+//
+//  Created by Zhengyang Hu on 1/15/26.
+//
+
+import AppKit
+import Foundation
+
+final class AppleMusicProvider: NowPlayingProvider {
+    let sourceName = "Apple Music"
+
+    func fetchState() async -> NowPlayingProviderState {
+        let script = """
+        set isRunning to (application "Music" is running)
+        if not isRunning then
+            return {false, false, "", "", missing value}
+        end if
+        tell application "Music"
+            set playerState to player state
+            if playerState is not playing then
+                return {true, false, "", "", missing value}
+            end if
+            set trackName to name of current track
+            set artistName to artist of current track
+            set artworkData to data of artwork 1 of current track
+            return {true, true, trackName, artistName, artworkData}
+        end tell
+        """
+
+        guard let result = await AppleScriptRunner.run(script) else {
+            return NowPlayingProviderState(isRunning: false, isPlaying: false, title: "", artist: "", artwork: nil)
+        }
+
+        let isRunning = result.descriptor(at: 1)?.booleanValue ?? false
+        let isPlaying = result.descriptor(at: 2)?.booleanValue ?? false
+        let title = result.descriptor(at: 3)?.stringValue ?? ""
+        let artist = result.descriptor(at: 4)?.stringValue ?? ""
+        let artworkData = result.descriptor(at: 5)?.data
+        let artwork = artworkData.flatMap { NSImage(data: $0) }
+
+        return NowPlayingProviderState(
+            isRunning: isRunning,
+            isPlaying: isPlaying,
+            title: title,
+            artist: artist,
+            artwork: artwork
+        )
+    }
+
+    func playPause() async {
+        let script = """
+        if application "Music" is running then
+            tell application "Music" to playpause
+        end if
+        """
+        _ = await AppleScriptRunner.run(script)
+    }
+
+    func nextTrack() async {
+        let script = """
+        if application "Music" is running then
+            tell application "Music" to next track
+        end if
+        """
+        _ = await AppleScriptRunner.run(script)
+    }
+
+    func previousTrack() async {
+        let script = """
+        if application "Music" is running then
+            tell application "Music" to previous track
+        end if
+        """
+        _ = await AppleScriptRunner.run(script)
+    }
+}
+
+private extension NSAppleEventDescriptor {
+    func descriptor(at index: Int) -> NSAppleEventDescriptor? {
+        if descriptorType == typeAEList {
+            return descriptor(atIndex: index)
+        }
+        return nil
+    }
+}

--- a/macos/Pomodoro/Pomodoro/AppleScriptRunner.swift
+++ b/macos/Pomodoro/Pomodoro/AppleScriptRunner.swift
@@ -1,0 +1,21 @@
+//
+//  AppleScriptRunner.swift
+//  Pomodoro
+//
+//  Created by Zhengyang Hu on 1/15/26.
+//
+
+import Foundation
+
+enum AppleScriptRunner {
+    static func run(_ script: String) async -> NSAppleEventDescriptor? {
+        await withCheckedContinuation { continuation in
+            DispatchQueue.global(qos: .userInitiated).async {
+                let appleScript = NSAppleScript(source: script)
+                var error: NSDictionary?
+                let result = appleScript?.executeAndReturnError(&error)
+                continuation.resume(returning: result)
+            }
+        }
+    }
+}

--- a/macos/Pomodoro/Pomodoro/ContentView.swift
+++ b/macos/Pomodoro/Pomodoro/ContentView.swift
@@ -17,6 +17,6 @@ struct ContentView: View {
     let appState = AppState()
     ContentView()
         .environmentObject(appState)
-        .environmentObject(appState.localMusicPlayer)
+        .environmentObject(appState.nowPlayingRouter)
         .environmentObject(MusicController(ambientNoiseEngine: appState.ambientNoiseEngine))
 }

--- a/macos/Pomodoro/Pomodoro/MainWindowView.swift
+++ b/macos/Pomodoro/Pomodoro/MainWindowView.swift
@@ -170,7 +170,7 @@ struct MainWindowView: View {
             }
 
             MediaControlBar()
-                .environmentObject(appState.mediaPlayer)
+                .environmentObject(appState.nowPlayingRouter)
         }
         .padding()
         .frame(minWidth: 360)

--- a/macos/Pomodoro/Pomodoro/MediaControlBar.swift
+++ b/macos/Pomodoro/Pomodoro/MediaControlBar.swift
@@ -8,53 +8,80 @@
 import SwiftUI
 
 struct MediaControlBar: View {
-    @EnvironmentObject private var mediaPlayer: LocalMediaPlayer
+    @EnvironmentObject private var nowPlaying: NowPlayingRouter
 
     var body: some View {
         HStack(spacing: 12) {
-            ZStack {
-                Circle()
-                    .fill(.quaternary)
-                Image(systemName: "music.note")
-                    .font(.system(size: 14, weight: .semibold))
-                    .foregroundStyle(.secondary)
-            }
-            .frame(width: 32, height: 32)
+            if nowPlaying.isAvailable {
+                artworkView
 
-            VStack(alignment: .leading, spacing: 4) {
-                Text(mediaPlayer.currentTrackTitle)
-                    .font(.system(.subheadline, design: .rounded))
-                    .foregroundStyle(.primary)
-                    .lineLimit(1)
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(nowPlaying.title)
+                        .font(.system(.subheadline, design: .rounded))
+                        .foregroundStyle(.primary)
+                        .lineLimit(1)
 
-                Button("Choose Music") {
-                    mediaPlayer.loadLocalFiles()
+                    Text("\(nowPlaying.artist) • \(nowPlaying.sourceName)")
+                        .font(.system(.caption, design: .rounded))
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
                 }
-                .buttonStyle(.link)
-                .font(.system(.caption, design: .rounded))
-            }
 
-            Spacer(minLength: 8)
+                Spacer(minLength: 8)
 
-            Button {
-                mediaPlayer.togglePlayPause()
-            } label: {
-                Image(systemName: mediaPlayer.isPlaying ? "pause.fill" : "play.fill")
-                    .font(.system(size: 14, weight: .semibold))
-                    .frame(width: 32, height: 32)
-            }
-            .buttonStyle(.plain)
-            .background(Circle().fill(.ultraThinMaterial))
+                Button {
+                    nowPlaying.previousTrack()
+                } label: {
+                    Image(systemName: "backward.fill")
+                        .font(.system(size: 14, weight: .semibold))
+                        .frame(width: 32, height: 32)
+                }
+                .buttonStyle(.plain)
+                .background(Circle().fill(.ultraThinMaterial))
 
-            Button {
-                mediaPlayer.nextTrack()
-            } label: {
-                Image(systemName: "forward.fill")
-                    .font(.system(size: 14, weight: .semibold))
-                    .frame(width: 32, height: 32)
+                Button {
+                    nowPlaying.playPause()
+                } label: {
+                    Image(systemName: nowPlaying.isPlaying ? "pause.fill" : "play.fill")
+                        .font(.system(size: 14, weight: .semibold))
+                        .frame(width: 32, height: 32)
+                }
+                .buttonStyle(.plain)
+                .background(Circle().fill(.ultraThinMaterial))
+
+                Button {
+                    nowPlaying.nextTrack()
+                } label: {
+                    Image(systemName: "forward.fill")
+                        .font(.system(size: 14, weight: .semibold))
+                        .frame(width: 32, height: 32)
+                }
+                .buttonStyle(.plain)
+                .background(Circle().fill(.ultraThinMaterial))
+            } else {
+                ZStack {
+                    Circle()
+                        .fill(.quaternary)
+                    Image(systemName: "music.note")
+                        .font(.system(size: 14, weight: .semibold))
+                        .foregroundStyle(.secondary)
+                }
+                .frame(width: 32, height: 32)
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("No supported music playing")
+                        .font(.system(.subheadline, design: .rounded))
+                        .foregroundStyle(.primary)
+                        .lineLimit(1)
+
+                    Text("Start Apple Music or Spotify")
+                        .font(.system(.caption, design: .rounded))
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+
+                Spacer(minLength: 8)
             }
-            .buttonStyle(.plain)
-            .background(Circle().fill(.ultraThinMaterial))
         }
         .padding(.horizontal, 16)
         .padding(.vertical, 10)
@@ -64,10 +91,30 @@ struct MediaControlBar: View {
                 .strokeBorder(.white.opacity(0.2))
         )
     }
+
+    @ViewBuilder
+    private var artworkView: some View {
+        if let artwork = nowPlaying.artwork {
+            Image(nsImage: artwork)
+                .resizable()
+                .scaledToFill()
+                .frame(width: 32, height: 32)
+                .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+        } else {
+            ZStack {
+                RoundedRectangle(cornerRadius: 6, style: .continuous)
+                    .fill(.quaternary)
+                Image(systemName: "music.note")
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundStyle(.secondary)
+            }
+            .frame(width: 32, height: 32)
+        }
+    }
 }
 
 #Preview {
     MediaControlBar()
-        .environmentObject(LocalMediaPlayer())
+        .environmentObject(NowPlayingRouter())
         .padding()
 }

--- a/macos/Pomodoro/Pomodoro/MenuBarController.swift
+++ b/macos/Pomodoro/Pomodoro/MenuBarController.swift
@@ -44,7 +44,6 @@ final class MenuBarController: NSObject, NSMenuDelegate {
     private let statusItem: NSStatusItem
     private let menu: NSMenu
     private let openMainWindow: () -> Void
-    private let openMusicPanel: () -> Void
     private let quitHandler: () -> Void
     private var titleTimer: Timer?
     private var lastTitleUpdateSecond: Int?
@@ -54,13 +53,11 @@ final class MenuBarController: NSObject, NSMenuDelegate {
         appState: AppState,
         musicController: MusicController,
         openMainWindow: @escaping () -> Void,
-        openMusicPanel: @escaping () -> Void,
         quitApp: @escaping () -> Void
     ) {
         self.appState = appState
         self.musicController = musicController
         self.openMainWindow = openMainWindow
-        self.openMusicPanel = openMusicPanel
         self.quitHandler = quitApp
         statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
         menu = NSMenu()
@@ -354,11 +351,6 @@ final class MenuBarController: NSObject, NSMenuDelegate {
         let ambientSoundItem = NSMenuItem(title: "Ambient Sound", action: nil, keyEquivalent: "")
         ambientSoundItem.submenu = ambientSoundMenu
         musicMenu.addItem(ambientSoundItem)
-        musicMenu.addItem(.separator())
-        musicMenu.addItem(actionItem(title: "⏮ Previous", action: #selector(previousTrack)))
-        musicMenu.addItem(actionItem(title: "⏭ Next", action: #selector(nextTrack)))
-        musicMenu.addItem(.separator())
-        musicMenu.addItem(actionItem(title: "Open Music Panel", action: #selector(openMusicPanelAction)))
 
         let musicItem = NSMenuItem(title: "Music", action: nil, keyEquivalent: "")
         musicItem.submenu = musicMenu
@@ -476,14 +468,6 @@ final class MenuBarController: NSObject, NSMenuDelegate {
         }
     }
 
-    @objc private func previousTrack() {
-        musicController.previous()
-    }
-
-    @objc private func nextTrack() {
-        musicController.next()
-    }
-
     @objc private func selectFocusSound(_ sender: NSMenuItem) {
         guard let sound = sender.representedObject as? FocusSoundType else { return }
         if sound == .off {
@@ -491,10 +475,6 @@ final class MenuBarController: NSObject, NSMenuDelegate {
         } else {
             musicController.startFocusSound(sound)
         }
-    }
-
-    @objc private func openMusicPanelAction() {
-        openMusicPanel()
     }
 
     @objc private func quitApp() {

--- a/macos/Pomodoro/Pomodoro/MusicPanelView.swift
+++ b/macos/Pomodoro/Pomodoro/MusicPanelView.swift
@@ -55,7 +55,6 @@ struct MusicPanelView: View {
 }
 
 #Preview {
-    let appState = AppState()
     MusicPanelView()
-        .environmentObject(appState.localMusicPlayer)
+        .environmentObject(LocalMusicPlayer())
 }

--- a/macos/Pomodoro/Pomodoro/NowPlayingProvider.swift
+++ b/macos/Pomodoro/Pomodoro/NowPlayingProvider.swift
@@ -1,0 +1,24 @@
+//
+//  NowPlayingProvider.swift
+//  Pomodoro
+//
+//  Created by Zhengyang Hu on 1/15/26.
+//
+
+import AppKit
+
+struct NowPlayingProviderState {
+    let isRunning: Bool
+    let isPlaying: Bool
+    let title: String
+    let artist: String
+    let artwork: NSImage?
+}
+
+protocol NowPlayingProvider {
+    var sourceName: String { get }
+    func fetchState() async -> NowPlayingProviderState
+    func playPause() async
+    func nextTrack() async
+    func previousTrack() async
+}

--- a/macos/Pomodoro/Pomodoro/NowPlayingRouter.swift
+++ b/macos/Pomodoro/Pomodoro/NowPlayingRouter.swift
@@ -1,0 +1,113 @@
+//
+//  NowPlayingRouter.swift
+//  Pomodoro
+//
+//  Created by Zhengyang Hu on 1/15/26.
+//
+
+import AppKit
+import Foundation
+
+@MainActor
+final class NowPlayingRouter: ObservableObject {
+    @Published private(set) var title: String = ""
+    @Published private(set) var artist: String = ""
+    @Published private(set) var artwork: NSImage?
+    @Published private(set) var sourceName: String = ""
+    @Published private(set) var isPlaying: Bool = false
+    @Published private(set) var isAvailable: Bool = false
+
+    private let appleMusicProvider: NowPlayingProvider
+    private let spotifyProvider: NowPlayingProvider
+    private let qqMusicProvider: NowPlayingProvider
+    private var pollTask: Task<Void, Never>?
+    private var activeProvider: NowPlayingProvider?
+
+    init(
+        appleMusicProvider: NowPlayingProvider = AppleMusicProvider(),
+        spotifyProvider: NowPlayingProvider = SpotifyProvider(),
+        qqMusicProvider: NowPlayingProvider = QQMusicProvider(),
+        startPolling: Bool = true
+    ) {
+        self.appleMusicProvider = appleMusicProvider
+        self.spotifyProvider = spotifyProvider
+        self.qqMusicProvider = qqMusicProvider
+
+        if startPolling {
+            startPollingLoop()
+        }
+    }
+
+    deinit {
+        pollTask?.cancel()
+    }
+
+    func playPause() {
+        guard let activeProvider else { return }
+        Task {
+            await activeProvider.playPause()
+        }
+    }
+
+    func nextTrack() {
+        guard let activeProvider else { return }
+        Task {
+            await activeProvider.nextTrack()
+        }
+    }
+
+    func previousTrack() {
+        guard let activeProvider else { return }
+        Task {
+            await activeProvider.previousTrack()
+        }
+    }
+
+    private func startPollingLoop() {
+        pollTask?.cancel()
+        pollTask = Task { [weak self] in
+            guard let self else { return }
+            while !Task.isCancelled {
+                await refresh()
+                try? await Task.sleep(nanoseconds: 750_000_000)
+            }
+        }
+    }
+
+    private func refresh() async {
+        async let appleState = appleMusicProvider.fetchState()
+        async let spotifyState = spotifyProvider.fetchState()
+        _ = qqMusicProvider
+
+        let apple = await appleState
+        let spotify = await spotifyState
+
+        if apple.isPlaying {
+            apply(state: apple, provider: appleMusicProvider)
+        } else if spotify.isPlaying {
+            apply(state: spotify, provider: spotifyProvider)
+        } else {
+            clearState()
+        }
+    }
+
+    private func apply(state: NowPlayingProviderState, provider: NowPlayingProvider) {
+        activeProvider = provider
+        title = state.title.isEmpty ? "Unknown Track" : state.title
+        artist = state.artist.isEmpty ? "Unknown Artist" : state.artist
+        artwork = state.artwork
+        sourceName = provider.sourceName
+        isPlaying = state.isPlaying
+        isAvailable = true
+    }
+
+    private func clearState() {
+        activeProvider = nil
+        title = ""
+        artist = ""
+        artwork = nil
+        sourceName = ""
+        isPlaying = false
+        isAvailable = false
+    }
+}

--- a/macos/Pomodoro/Pomodoro/PomodoroApp.swift
+++ b/macos/Pomodoro/Pomodoro/PomodoroApp.swift
@@ -23,7 +23,7 @@ struct PomodoroApp: App {
         WindowGroup {
             ContentView()
                 .environmentObject(appState)
-                .environmentObject(appState.localMusicPlayer)
+                .environmentObject(appState.nowPlayingRouter)
                 .environmentObject(musicController)
                 .task(id: ObjectIdentifier(appState)) {
                     appDelegate.appState = appState

--- a/macos/Pomodoro/Pomodoro/QQMusicProvider.swift
+++ b/macos/Pomodoro/Pomodoro/QQMusicProvider.swift
@@ -1,0 +1,22 @@
+//
+//  QQMusicProvider.swift
+//  Pomodoro
+//
+//  Created by Zhengyang Hu on 1/15/26.
+//
+
+import AppKit
+
+/// Placeholder provider for a future official QQ Music SDK integration.
+/// This remains disabled until an official SDK is available.
+final class QQMusicProvider: NowPlayingProvider {
+    let sourceName = "QQ Music"
+
+    func fetchState() async -> NowPlayingProviderState {
+        NowPlayingProviderState(isRunning: false, isPlaying: false, title: "", artist: "", artwork: nil)
+    }
+
+    func playPause() async {}
+    func nextTrack() async {}
+    func previousTrack() async {}
+}

--- a/macos/Pomodoro/Pomodoro/SpotifyProvider.swift
+++ b/macos/Pomodoro/Pomodoro/SpotifyProvider.swift
@@ -1,0 +1,112 @@
+//
+//  SpotifyProvider.swift
+//  Pomodoro
+//
+//  Created by Zhengyang Hu on 1/15/26.
+//
+
+import AppKit
+import Foundation
+
+final class SpotifyProvider: NowPlayingProvider {
+    let sourceName = "Spotify"
+    private var cachedArtworkURL: String?
+    private var cachedArtwork: NSImage?
+
+    func fetchState() async -> NowPlayingProviderState {
+        guard isSpotifyInstalled() else {
+            return NowPlayingProviderState(isRunning: false, isPlaying: false, title: "", artist: "", artwork: nil)
+        }
+
+        let script = """
+        set isRunning to (application "Spotify" is running)
+        if not isRunning then
+            return {false, false, "", "", ""}
+        end if
+        tell application "Spotify"
+            set playerState to player state
+            if playerState is not playing then
+                return {true, false, "", "", ""}
+            end if
+            set trackName to name of current track
+            set artistName to artist of current track
+            set artworkUrl to artwork url of current track
+            return {true, true, trackName, artistName, artworkUrl}
+        end tell
+        """
+
+        guard let result = await AppleScriptRunner.run(script) else {
+            return NowPlayingProviderState(isRunning: false, isPlaying: false, title: "", artist: "", artwork: nil)
+        }
+
+        let isRunning = result.descriptor(at: 1)?.booleanValue ?? false
+        let isPlaying = result.descriptor(at: 2)?.booleanValue ?? false
+        let title = result.descriptor(at: 3)?.stringValue ?? ""
+        let artist = result.descriptor(at: 4)?.stringValue ?? ""
+        let artworkURLString = result.descriptor(at: 5)?.stringValue ?? ""
+        let artwork = await resolveArtwork(urlString: artworkURLString)
+
+        return NowPlayingProviderState(
+            isRunning: isRunning,
+            isPlaying: isPlaying,
+            title: title,
+            artist: artist,
+            artwork: artwork
+        )
+    }
+
+    func playPause() async {
+        let script = """
+        if application "Spotify" is running then
+            tell application "Spotify" to playpause
+        end if
+        """
+        _ = await AppleScriptRunner.run(script)
+    }
+
+    func nextTrack() async {
+        let script = """
+        if application "Spotify" is running then
+            tell application "Spotify" to next track
+        end if
+        """
+        _ = await AppleScriptRunner.run(script)
+    }
+
+    func previousTrack() async {
+        let script = """
+        if application "Spotify" is running then
+            tell application "Spotify" to previous track
+        end if
+        """
+        _ = await AppleScriptRunner.run(script)
+    }
+
+    private func isSpotifyInstalled() -> Bool {
+        NSWorkspace.shared.urlForApplication(withBundleIdentifier: "com.spotify.client") != nil
+    }
+
+    private func resolveArtwork(urlString: String) async -> NSImage? {
+        guard !urlString.isEmpty else {
+            cachedArtworkURL = nil
+            cachedArtwork = nil
+            return nil
+        }
+
+        if cachedArtworkURL == urlString, let cachedArtwork {
+            return cachedArtwork
+        }
+
+        guard let url = URL(string: urlString) else { return nil }
+
+        do {
+            let (data, _) = try await URLSession.shared.data(from: url)
+            let image = NSImage(data: data)
+            cachedArtworkURL = urlString
+            cachedArtwork = image
+            return image
+        } catch {
+            return nil
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Introduce a premium, provider-driven Now Playing experience that reliably detects and controls Apple Music and Spotify while avoiding misleading fallbacks.
- Keep the existing ambient noise engine unchanged and focus media work on App Store-safe approaches (AppleScript for scripting, no private APIs).

### Description
- Add a `NowPlayingProvider` protocol and concrete providers `AppleMusicProvider` and `SpotifyProvider` that use asynchronous AppleScript via `AppleScriptRunner` to fetch running/playing state, metadata, and artwork and to perform play/pause/next/previous actions.
- Add `NowPlayingRouter` (an `ObservableObject`) that polls providers (~750ms interval), prioritizes Apple Music if playing, falls back to Spotify, and exposes the unified state to SwiftUI: `title`, `artist`, `artwork`, `sourceName`, `isPlaying`, and `isAvailable`.
- Update `MediaControlBar` to bind only to `NowPlayingRouter`, show high-quality artwork and metadata when available, provide responsive `previous` / `playPause` / `next` controls, and display an honest premium empty state `"No supported music playing" / "Start Apple Music or Spotify"` when no supported source is active.
- Add a `QQMusicProvider` placeholder (disabled) with a clear comment that it will be enabled only via an official SDK in future work.
- Integrate the router into the app wiring by adding `nowPlayingRouter` to `AppState` and propagating it through the UI; remove previous generic music-panel/menu paths and the MusicController system-media coupling so the app does not pretend to support unsupported sources.
- Implementations include safe, asynchronous AppleScript execution, Spotify artwork URL caching and remote fetch, and non-blocking polling on a background task.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e0913e6b08323aba95a09cb9c0151)