### PR TITLE
Add configurable Countdown Timer (state + UI)

### DIFF
--- a/macos/PomodoroApp/CountdownTimerState.swift
+++ b/macos/PomodoroApp/CountdownTimerState.swift
@@ -1,0 +1,86 @@
+import Foundation
+
+@MainActor
+final class CountdownTimerState: ObservableObject {
+    @Published private(set) var duration: TimeInterval
+    @Published private(set) var remainingTime: TimeInterval
+    @Published private(set) var isRunning = false
+    @Published private(set) var isPaused = false
+
+    private let durationKey = "countdownDurationSeconds"
+    private var timer: Timer?
+
+    init() {
+        let storedDuration = UserDefaults.standard.double(forKey: durationKey)
+        let initialDuration = storedDuration > 0 ? storedDuration : 10 * 60
+        duration = initialDuration
+        remainingTime = initialDuration
+    }
+
+    func setDuration(minutes: Int) {
+        let newDuration = TimeInterval(minutes * 60)
+        duration = newDuration
+        remainingTime = newDuration
+        persistDuration()
+        stopTimer()
+        isPaused = false
+    }
+
+    func start() {
+        guard !isRunning else { return }
+        if remainingTime <= 0 {
+            remainingTime = duration
+        }
+        isRunning = true
+        isPaused = false
+        startTimer()
+    }
+
+    func pause() {
+        guard isRunning else { return }
+        isRunning = false
+        isPaused = true
+        stopTimer()
+    }
+
+    func resume() {
+        guard !isRunning, isPaused, remainingTime > 0 else { return }
+        isRunning = true
+        isPaused = false
+        startTimer()
+    }
+
+    func reset() {
+        isRunning = false
+        isPaused = false
+        remainingTime = duration
+        stopTimer()
+    }
+
+    private func startTimer() {
+        stopTimer()
+        timer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { [weak self] _ in
+            self?.tick()
+        }
+    }
+
+    private func stopTimer() {
+        timer?.invalidate()
+        timer = nil
+    }
+
+    private func tick() {
+        guard remainingTime > 0 else {
+            remainingTime = 0
+            isRunning = false
+            isPaused = false
+            stopTimer()
+            return
+        }
+        remainingTime -= 1
+    }
+
+    private func persistDuration() {
+        UserDefaults.standard.set(duration, forKey: durationKey)
+    }
+}

--- a/macos/PomodoroApp/CountdownTimerView.swift
+++ b/macos/PomodoroApp/CountdownTimerView.swift
@@ -1,0 +1,81 @@
+import SwiftUI
+
+struct CountdownTimerView: View {
+    @EnvironmentObject private var countdownState: CountdownTimerState
+    @State private var selectedMinutes: Int = 10
+
+    private let minuteOptions = Array(stride(from: 1, through: 120, by: 1))
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Text("Countdown Timer")
+                    .font(.headline)
+                Spacer()
+                Text(timeString(from: countdownState.remainingTime))
+                    .font(.title3)
+                    .monospacedDigit()
+            }
+
+            HStack(spacing: 12) {
+                Picker("Duration", selection: $selectedMinutes) {
+                    ForEach(minuteOptions, id: \.self) { minutes in
+                        Text("\(minutes) min").tag(minutes)
+                    }
+                }
+                .frame(maxWidth: 160)
+                .onChange(of: selectedMinutes) { newValue in
+                    countdownState.setDuration(minutes: newValue)
+                }
+
+                Spacer()
+
+                HStack(spacing: 8) {
+                    Button("Start") {
+                        countdownState.start()
+                    }
+                    .disabled(countdownState.isRunning)
+
+                    Button("Pause") {
+                        countdownState.pause()
+                    }
+                    .disabled(!countdownState.isRunning)
+
+                    Button("Resume") {
+                        countdownState.resume()
+                    }
+                    .disabled(!countdownState.isPaused)
+
+                    Button("Reset") {
+                        countdownState.reset()
+                    }
+                    .disabled(countdownState.remainingTime == countdownState.duration && !countdownState.isRunning)
+                }
+            }
+        }
+        .onAppear {
+            selectedMinutes = max(1, Int(countdownState.duration / 60))
+        }
+        .onChange(of: countdownState.duration) { newValue in
+            let newMinutes = max(1, Int(newValue / 60))
+            if newMinutes != selectedMinutes {
+                selectedMinutes = newMinutes
+            }
+        }
+        .padding()
+        .background(.quaternary.opacity(0.2), in: RoundedRectangle(cornerRadius: 12))
+    }
+
+    private func timeString(from seconds: TimeInterval) -> String {
+        let totalSeconds = max(0, Int(seconds))
+        let minutes = totalSeconds / 60
+        let remainingSeconds = totalSeconds % 60
+        return String(format: "%02d:%02d", minutes, remainingSeconds)
+    }
+}
+
+#Preview {
+    CountdownTimerView()
+        .environmentObject(CountdownTimerState())
+        .padding()
+}

--- a/macos/PomodoroApp/MainWindowView.swift
+++ b/macos/PomodoroApp/MainWindowView.swift
@@ -9,6 +9,7 @@ struct MainWindowView: View {
                 .font(.largeTitle)
             Text("Ready to focus.")
                 .foregroundStyle(.secondary)
+            CountdownTimerView()
             MediaControlBar()
             DebugStateView()
         }

--- a/macos/PomodoroApp/PomodoroApp.swift
+++ b/macos/PomodoroApp/PomodoroApp.swift
@@ -4,6 +4,7 @@ import SwiftUI
 @main
 struct PomodoroApp: App {
     @StateObject private var appState = AppState()
+    @StateObject private var countdownState = CountdownTimerState()
     @State private var menuBarController: MenuBarController?
 
     init() {
@@ -19,6 +20,7 @@ struct PomodoroApp: App {
         WindowGroup {
             MainWindowView()
                 .environmentObject(appState)
+                .environmentObject(countdownState)
                 .task {
                     if menuBarController == nil {
                         menuBarController = MenuBarController(


### PR DESCRIPTION
### Motivation
- Provide a user-configurable standalone countdown timer separate from the Pomodoro engine so users can run ad-hoc countdowns without affecting Pomodoro stats.
- Persist the last-used duration so the timer remembers user preference across launches.
- Expose simple, system-friendly controls (start / pause / resume / reset) and a duration picker in the main UI while keeping a clear separation of concerns.

### Description
- Added `CountdownTimerState` (`macos/PomodoroApp/CountdownTimerState.swift`) as an `@MainActor` `ObservableObject` that owns `duration`, `remainingTime`, `isRunning`, `isPaused`, and a private `Timer`, with persistence to `UserDefaults` under the key `countdownDurationSeconds`.
- Added `CountdownTimerView` (`macos/PomodoroApp/CountdownTimerView.swift`) which shows remaining time, a minute `Picker` (1–120), and `Start` / `Pause` / `Resume` / `Reset` buttons, and updates when `duration` changes.
- Wired the countdown into the app by injecting `CountdownTimerState` into the environment in `PomodoroApp` and embedding `CountdownTimerView` into `MainWindowView` so UI updates are driven via `@EnvironmentObject`.
- Maintains strict separation from the Pomodoro engine by not touching `AppState` or Pomodoro logic and by avoiding any shared mutable state between the two timers.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f54b56a7c83238ba91a089ecd17cc)