### PR TITLE
Apply translucent vibrancy background to main window

### DIFF
--- a/macos/PomodoroApp/MainWindowView.swift
+++ b/macos/PomodoroApp/MainWindowView.swift
@@ -4,17 +4,24 @@ struct MainWindowView: View {
     @EnvironmentObject private var appState: AppState
 
     var body: some View {
-        VStack(spacing: 16) {
-            Text("Pomodoro")
-                .font(.largeTitle)
-            Text("Ready to focus.")
-                .foregroundStyle(.secondary)
-            CountdownTimerView()
-            MediaControlBar()
-            DebugStateView()
+        ZStack {
+            Rectangle()
+                .fill(.ultraThinMaterial)
+                .ignoresSafeArea()
+
+            VStack(spacing: 16) {
+                Text("Pomodoro")
+                    .font(.largeTitle)
+                Text("Ready to focus.")
+                    .foregroundStyle(.secondary)
+                CountdownTimerView()
+                MediaControlBar()
+                DebugStateView()
+            }
+            .frame(minWidth: 480, minHeight: 320)
+            .padding(32)
         }
-        .frame(minWidth: 480, minHeight: 320)
-        .padding(32)
+        .background(WindowBackgroundConfigurator())
         .task {
             // Connect to system media after first render to prevent blocking main thread
             #if DEBUG

--- a/macos/PomodoroApp/WindowBackgroundConfigurator.swift
+++ b/macos/PomodoroApp/WindowBackgroundConfigurator.swift
@@ -1,0 +1,26 @@
+import AppKit
+import SwiftUI
+
+struct WindowBackgroundConfigurator: NSViewRepresentable {
+    final class HostingView: NSView {
+        override func viewDidMoveToWindow() {
+            super.viewDidMoveToWindow()
+            applyWindowStyling()
+        }
+
+        func applyWindowStyling() {
+            guard let window else { return }
+            window.isOpaque = false
+            window.backgroundColor = .clear
+            window.titlebarAppearsTransparent = true
+        }
+    }
+
+    func makeNSView(context: Context) -> HostingView {
+        HostingView()
+    }
+
+    func updateNSView(_ nsView: HostingView, context: Context) {
+        nsView.applyWindowStyling()
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a system-native translucent/background vibrancy for the main window using public APIs to match Control Center / Settings-style translucency.
- Make the window background clear and allow SwiftUI/AppKit materials to show wallpaper and adapt to light/dark modes automatically.
- Ensure the material covers the entire window and that app content sits visually above the material without custom sampling or private APIs.

### Description
- Add `WindowBackgroundConfigurator`, an `NSViewRepresentable` that sets `window.isOpaque = false`, `window.backgroundColor = .clear`, and `window.titlebarAppearsTransparent = true` to enable window-level translucency. 
- Replace the previous root layout in `MainWindowView` with a `ZStack` that places a `Rectangle().fill(.ultraThinMaterial).ignoresSafeArea()` behind the app UI so the material covers the full window. 
- Keep app content (the `VStack`) above the material and attach the configurator via `.background(WindowBackgroundConfigurator())` so both SwiftUI material and AppKit window styling are applied. 
- Implementation uses only public APIs (`ultraThinMaterial`, `NSViewRepresentable`, `NSWindow` properties) and avoids custom shaders or wallpaper sampling.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f6309859083238189d19a94aac2a2)