### PR TITLE
Add first-launch onboarding flow with notification delivery choice and in-app notifications

### DIFF
--- a/macos/Pomodoro/Pomodoro/ContentView.swift
+++ b/macos/Pomodoro/Pomodoro/ContentView.swift
@@ -8,8 +8,15 @@
 import SwiftUI
 
 struct ContentView: View {
+    @EnvironmentObject private var onboardingState: OnboardingState
+
     var body: some View {
         MainWindowView()
+            .sheet(isPresented: $onboardingState.isPresented, onDismiss: {
+                onboardingState.markCompleted()
+            }) {
+                OnboardingFlowView()
+            }
     }
 }
 
@@ -19,4 +26,5 @@ struct ContentView: View {
         .environmentObject(appState)
         .environmentObject(appState.nowPlayingRouter)
         .environmentObject(MusicController(ambientNoiseEngine: appState.ambientNoiseEngine))
+        .environmentObject(OnboardingState())
 }

--- a/macos/Pomodoro/Pomodoro/NotificationPreference.swift
+++ b/macos/Pomodoro/Pomodoro/NotificationPreference.swift
@@ -26,6 +26,31 @@ enum NotificationPreference: String, CaseIterable, Identifiable {
     }
 }
 
+enum NotificationDeliveryStyle: String, CaseIterable, Identifiable {
+    case system
+    case inApp
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .system:
+            return "System Notifications"
+        case .inApp:
+            return "In-App Popup"
+        }
+    }
+
+    var detail: String {
+        switch self {
+        case .system:
+            return "Use macOS banners or alerts."
+        case .inApp:
+            return "Show a confirmation popup inside the app window."
+        }
+    }
+}
+
 enum ReminderPreference: String, CaseIterable, Identifiable {
     case off
     case oneMinute

--- a/macos/Pomodoro/Pomodoro/OnboardingFlowView.swift
+++ b/macos/Pomodoro/Pomodoro/OnboardingFlowView.swift
@@ -1,0 +1,243 @@
+//
+//  OnboardingFlowView.swift
+//  Pomodoro
+//
+//  Created by OpenAI on 2025-02-01.
+//
+
+import AppKit
+import SwiftUI
+import UserNotifications
+
+struct OnboardingFlowView: View {
+    @EnvironmentObject private var appState: AppState
+    @EnvironmentObject private var onboardingState: OnboardingState
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    @State private var step: OnboardingStep = .welcome
+    @State private var authorizationStatus: UNAuthorizationStatus = .notDetermined
+    @State private var isRequestingAuthorization = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 20) {
+            HStack {
+                Text(step.title)
+                    .font(.system(.title, design: .rounded).weight(.semibold))
+                Spacer()
+                Button("Not Now") {
+                    onboardingState.markCompleted()
+                }
+                .buttonStyle(.borderless)
+            }
+
+            stepContent
+
+            Spacer()
+
+            HStack {
+                if step != .welcome {
+                    Button("Back") {
+                        step = step.previous(using: appState.notificationDeliveryStyle)
+                    }
+                }
+                Spacer()
+                Button(step == .media ? "Finish" : "Continue") {
+                    advance()
+                }
+                .buttonStyle(.borderedProminent)
+            }
+        }
+        .padding(32)
+        .frame(width: 520, height: 360)
+        .animation(reduceMotion ? nil : .easeInOut(duration: 0.2), value: step)
+        .onAppear {
+            refreshAuthorizationStatusIfNeeded()
+        }
+        .onChange(of: step) { _, _ in
+            refreshAuthorizationStatusIfNeeded()
+        }
+    }
+
+    @ViewBuilder
+    private var stepContent: some View {
+        switch step {
+        case .welcome:
+            VStack(alignment: .leading, spacing: 12) {
+                Text("Pomodoro helps you focus with structured work and break sessions.")
+                    .font(.system(.body, design: .rounded))
+                    .foregroundStyle(.secondary)
+            }
+        case .notificationStyle:
+            VStack(alignment: .leading, spacing: 12) {
+                Text("Choose how you want to be notified when sessions end.")
+                    .font(.system(.body, design: .rounded))
+                    .foregroundStyle(.secondary)
+
+                Picker("Notification Style", selection: $appState.notificationDeliveryStyle) {
+                    ForEach(NotificationDeliveryStyle.allCases) { style in
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(style.title)
+                            Text(style.detail)
+                                .font(.system(.caption, design: .rounded))
+                                .foregroundStyle(.secondary)
+                        }
+                        .tag(style)
+                    }
+                }
+                .pickerStyle(.radioGroup)
+            }
+        case .notificationPermission:
+            VStack(alignment: .leading, spacing: 12) {
+                Text("Pomodoro can notify you when sessions end.")
+                    .font(.system(.body, design: .rounded))
+                    .foregroundStyle(.secondary)
+
+                statusRow
+
+                HStack(spacing: 12) {
+                    Button(isRequestingAuthorization ? "Requesting..." : "Enable Notifications") {
+                        requestAuthorization()
+                    }
+                    .buttonStyle(.bordered)
+                    .disabled(isRequestingAuthorization)
+
+                    if authorizationStatus == .denied {
+                        Button("Open System Settings") {
+                            openNotificationSettings()
+                        }
+                        .buttonStyle(.bordered)
+                    }
+                }
+            }
+        case .media:
+            VStack(alignment: .leading, spacing: 12) {
+                Text("Audio & Music")
+                    .font(.system(.headline, design: .rounded))
+                Text("Pomodoro includes built-in focus sounds that work without any permission.")
+                    .font(.system(.body, design: .rounded))
+                    .foregroundStyle(.secondary)
+                Text("Optional Apple Music or Spotify integration is possible later using their official SDKs.")
+                    .font(.system(.body, design: .rounded))
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    private var statusRow: some View {
+        HStack(spacing: 8) {
+            Circle()
+                .fill(statusColor)
+                .frame(width: 8, height: 8)
+            Text(statusText)
+                .font(.system(.callout, design: .rounded))
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private var statusText: String {
+        switch authorizationStatus {
+        case .authorized, .provisional:
+            return "Notifications are enabled."
+        case .denied:
+            return "Notifications are turned off in System Settings."
+        case .notDetermined:
+            return "Notifications have not been requested yet."
+        case .ephemeral:
+            return "Notifications are temporarily available."
+        @unknown default:
+            return "Notification status unavailable."
+        }
+    }
+
+    private var statusColor: Color {
+        switch authorizationStatus {
+        case .authorized, .provisional:
+            return .green
+        case .denied:
+            return .red
+        case .notDetermined:
+            return .orange
+        case .ephemeral:
+            return .blue
+        @unknown default:
+            return .gray
+        }
+    }
+
+    private func refreshAuthorizationStatusIfNeeded() {
+        guard step == .notificationPermission else { return }
+        UNUserNotificationCenter.current().getNotificationSettings { settings in
+            DispatchQueue.main.async {
+                authorizationStatus = settings.authorizationStatus
+            }
+        }
+    }
+
+    private func requestAuthorization() {
+        guard !isRequestingAuthorization else { return }
+        isRequestingAuthorization = true
+        appState.requestSystemNotificationAuthorization { status in
+            authorizationStatus = status
+            isRequestingAuthorization = false
+        }
+    }
+
+    private func openNotificationSettings() {
+        guard let url = URL(string: "x-apple.systempreferences:com.apple.preference.notifications") else { return }
+        NSWorkspace.shared.open(url)
+    }
+
+    private func advance() {
+        if let next = step.next(using: appState.notificationDeliveryStyle) {
+            step = next
+        } else {
+            onboardingState.markCompleted()
+        }
+    }
+}
+
+private enum OnboardingStep: Int, CaseIterable {
+    case welcome
+    case notificationStyle
+    case notificationPermission
+    case media
+
+    var title: String {
+        switch self {
+        case .welcome:
+            return "Welcome to Pomodoro"
+        case .notificationStyle:
+            return "Notification Style"
+        case .notificationPermission:
+            return "Enable Notifications"
+        case .media:
+            return "Audio & Music"
+        }
+    }
+
+    func next(using deliveryStyle: NotificationDeliveryStyle) -> OnboardingStep? {
+        switch self {
+        case .welcome:
+            return .notificationStyle
+        case .notificationStyle:
+            return deliveryStyle == .system ? .notificationPermission : .media
+        case .notificationPermission:
+            return .media
+        case .media:
+            return nil
+        }
+    }
+
+    func previous(using deliveryStyle: NotificationDeliveryStyle) -> OnboardingStep {
+        switch self {
+        case .welcome:
+            return .welcome
+        case .notificationStyle:
+            return .welcome
+        case .notificationPermission:
+            return .notificationStyle
+        case .media:
+            return deliveryStyle == .system ? .notificationPermission : .notificationStyle
+        }
+    }
+}

--- a/macos/Pomodoro/Pomodoro/OnboardingState.swift
+++ b/macos/Pomodoro/Pomodoro/OnboardingState.swift
@@ -1,0 +1,32 @@
+//
+//  OnboardingState.swift
+//  Pomodoro
+//
+//  Created by OpenAI on 2025-02-01.
+//
+
+import Foundation
+
+final class OnboardingState: ObservableObject {
+    @Published var isPresented: Bool
+
+    private let userDefaults: UserDefaults
+
+    init(userDefaults: UserDefaults = .standard) {
+        self.userDefaults = userDefaults
+        self.isPresented = !userDefaults.bool(forKey: DefaultsKey.onboardingCompleted)
+    }
+
+    func markCompleted() {
+        userDefaults.set(true, forKey: DefaultsKey.onboardingCompleted)
+        isPresented = false
+    }
+
+    func reopen() {
+        isPresented = true
+    }
+
+    private enum DefaultsKey {
+        static let onboardingCompleted = "onboarding.completed"
+    }
+}

--- a/macos/Pomodoro/Pomodoro/PomodoroApp.swift
+++ b/macos/Pomodoro/Pomodoro/PomodoroApp.swift
@@ -12,11 +12,13 @@ struct PomodoroApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
     @StateObject private var appState: AppState
     @StateObject private var musicController: MusicController
+    @StateObject private var onboardingState: OnboardingState
 
     init() {
         let appState = AppState()
         _appState = StateObject(wrappedValue: appState)
         _musicController = StateObject(wrappedValue: MusicController(ambientNoiseEngine: appState.ambientNoiseEngine))
+        _onboardingState = StateObject(wrappedValue: OnboardingState())
     }
 
     var body: some Scene {
@@ -25,6 +27,7 @@ struct PomodoroApp: App {
                 .environmentObject(appState)
                 .environmentObject(appState.nowPlayingRouter)
                 .environmentObject(musicController)
+                .environmentObject(onboardingState)
                 .task(id: ObjectIdentifier(appState)) {
                     appDelegate.appState = appState
                     appDelegate.musicController = musicController


### PR DESCRIPTION
### Motivation
- Provide a lightweight, Apple-style first-launch setup that runs once and lets users choose notification delivery and learn about media features without forcing permissions.
- Respect accessibility and non-blocking UI by making the flow skippable, re-openable from Settings, and animated with `Reduce Motion` support.

### Description
- Add a persisted onboarding controller `OnboardingState` that shows the flow once and stores the one-time completion flag under `onboarding.completed` in `UserDefaults`.
- Implement `OnboardingFlowView` as a small multi-step SwiftUI flow (Welcome → Notification Style → Optional Request Permission → Media explanation) that saves the delivery style and only requests notification authorization when the user chooses the System option by calling `AppState.requestSystemNotificationAuthorization`.
- Introduce `NotificationDeliveryStyle` in `NotificationPreference.swift` and wire a new `notificationDeliveryStyle` property into `AppState`, persist it to `UserDefaults`, and gate automatic authorization requests to System-only choices.
- Add in-app notification popups (`NotificationPopup`) and `showNotificationPopup` handling in `AppState`, have `sendNotification` respect the selected delivery style, and render in-app notifications in `MainWindowView` via `InAppNotificationView` while preserving existing transition popups.
- Wire onboarding presentation: present the onboarding as a sheet on first launch from `ContentView`, provide an `Open Onboarding` button in `MainWindowView`, and register `OnboardingState` as a `@StateObject` in `PomodoroApp` so it is available at startup.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f7566d90483238bc29b4e53489171)