### PR TITLE
Replace onboarding action in Settings with quick actions and preference selectors

### DIFF
--- a/macos/Pomodoro/Pomodoro/MainWindowView.swift
+++ b/macos/Pomodoro/Pomodoro/MainWindowView.swift
@@ -5,12 +5,12 @@
 //  Created by Zhengyang Hu on 1/15/26.
 //
 
+import AppKit
 import SwiftUI
 
 struct MainWindowView: View {
     @EnvironmentObject private var appState: AppState
     @EnvironmentObject private var musicController: MusicController
-    @EnvironmentObject private var onboardingState: OnboardingState
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var workMinutesText = ""
     @State private var shortBreakMinutesText = ""
@@ -336,13 +336,43 @@ struct MainWindowView: View {
             }
 
             VStack(alignment: .leading, spacing: 8) {
-                Text("Setup")
+                Text("Quick Actions")
                     .font(.system(.headline, design: .rounded))
                     .foregroundStyle(.secondary)
-                Button("Open Onboarding") {
-                    onboardingState.reopen()
+                HStack(spacing: 12) {
+                    Button("Request Notifications") {
+                        appState.requestSystemNotificationAuthorization { _ in }
+                    }
+                    .buttonStyle(.bordered)
+
+                    Button("Open Notification Settings") {
+                        openNotificationSettings()
+                    }
+                    .buttonStyle(.bordered)
                 }
-                .buttonStyle(.bordered)
+            }
+
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Preferences")
+                    .font(.system(.headline, design: .rounded))
+                    .foregroundStyle(.secondary)
+                Picker("Default Preset", selection: presetSelectionBinding) {
+                    ForEach(Preset.builtIn) { preset in
+                        Text(preset.name)
+                            .tag(PresetSelection.preset(preset))
+                    }
+                    Text("Custom")
+                        .tag(PresetSelection.custom)
+                }
+                .pickerStyle(.segmented)
+
+                Picker("Focus Sound", selection: ambientSoundBinding) {
+                    ForEach(FocusSoundType.allCases) { sound in
+                        Text(sound.displayName)
+                            .tag(sound)
+                    }
+                }
+                .pickerStyle(.segmented)
             }
         }
         .padding(.top, 28)
@@ -362,6 +392,11 @@ struct MainWindowView: View {
                 }
             }
         )
+    }
+
+    private func openNotificationSettings() {
+        guard let url = URL(string: "x-apple.systempreferences:com.apple.preference.notifications") else { return }
+        NSWorkspace.shared.open(url)
     }
 
     private enum DurationField: Hashable {


### PR DESCRIPTION
### Motivation

- The Settings pane should no longer surface the onboarding flow, and instead offer direct controls for notification and preference management.
- Provide quick, discoverable actions for notifications and common preferences to simplify user setup without launching the onboarding UI.

### Description

- Removed the `onboardingState` environment usage and the `Open Onboarding` button from the settings section in `MainWindowView.swift`.
- Added a `Quick Actions` group with `Request Notifications` (calls `appState.requestSystemNotificationAuthorization`) and `Open Notification Settings` buttons that invoke a new helper `openNotificationSettings()`.
- Added a `Preferences` group with segmented `Picker`s for `Default Preset` (uses `presetSelectionBinding`) and `Focus Sound` (uses `ambientSoundBinding`) inside `MainWindowView.swift`.
- Imported `AppKit` and added the helper function `openNotificationSettings()` which opens the macOS notification preference pane URL.

### Testing

- No automated tests were run on this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69738929b06083238975cd3749926891)