### PR TITLE
Open macOS System Settings for Calendar & Reminders access

### DIFF
--- a/macos/Pomodoro/Pomodoro/MainWindowView.swift
+++ b/macos/Pomodoro/Pomodoro/MainWindowView.swift
@@ -6,7 +6,6 @@
 //
 
 import AppKit
-import EventKit
 import SwiftUI
 
 struct MainWindowView: View {
@@ -22,7 +21,6 @@ struct MainWindowView: View {
     @State private var sidebarSelection: SidebarItem = .pomodoro
     @State private var pomodoroStatePulse = false
     @State private var countdownStatePulse = false
-    private let eventStore = EKEventStore()
 
     var body: some View {
         ZStack(alignment: .top) {
@@ -355,12 +353,12 @@ struct MainWindowView: View {
 
                 HStack(spacing: 12) {
                     Button("Get Calendar Access") {
-                        requestCalendarAccess()
+                        openCalendarSettings()
                     }
                     .buttonStyle(.bordered)
 
                     Button("Get Reminders Access") {
-                        requestRemindersAccess()
+                        openRemindersSettings()
                     }
                     .buttonStyle(.bordered)
                 }
@@ -391,12 +389,14 @@ struct MainWindowView: View {
         NSWorkspace.shared.open(url)
     }
 
-    private func requestCalendarAccess() {
-        eventStore.requestAccess(to: .event) { _, _ in }
+    private func openCalendarSettings() {
+        guard let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Calendars") else { return }
+        NSWorkspace.shared.open(url)
     }
 
-    private func requestRemindersAccess() {
-        eventStore.requestAccess(to: .reminder) { _, _ in }
+    private func openRemindersSettings() {
+        guard let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Reminders") else { return }
+        NSWorkspace.shared.open(url)
     }
 
     private enum DurationField: Hashable {


### PR DESCRIPTION
### Motivation
- Provide a predictable UX for a sandboxed macOS app by redirecting users to System Settings instead of invoking EventKit permission APIs which can silently fail under sandboxing.

### Description
- Removed `import EventKit` and the `eventStore` property from `MainWindowView`.
- Updated the "Get Calendar Access" and "Get Reminders Access" buttons to call `openCalendarSettings()` and `openRemindersSettings()` respectively.
- Added `openCalendarSettings()` and `openRemindersSettings()` helpers that use `NSWorkspace.shared.open` with `x-apple.systempreferences:com.apple.preference.security?Privacy_Calendars` and `x-apple.systempreferences:com.apple.preference.security?Privacy_Reminders` URLs.
- Left the existing `openNotificationSettings()` implementation and related UI unchanged.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69742fa4ae788323bfeef2954025883c)