### PR TITLE
[codex] Stabilize app controls and selectors

### DIFF
--- a/macos/Pomodoro/Pomodoro/AIAssistantView.swift
+++ b/macos/Pomodoro/Pomodoro/AIAssistantView.swift
@@ -26,9 +26,9 @@ enum AIAssistantAction: String, CaseIterable, Identifiable {
         case .breakdown:
             return "list.bullet.rectangle.portrait"
         case .draftFromIdea:
-            return "sparkles.rectangle.stack"
+            return "text.badge.plus"
         case .planning:
-            return "sparkles"
+            return "calendar.badge.clock"
         case .reschedule:
             return "calendar.badge.clock"
         }
@@ -89,7 +89,7 @@ struct AIAssistantView: View {
                 Button(localizationManager.text("common.cancel")) {
                     onClose()
                 }
-                .buttonStyle(.bordered)
+                .orchestranaButton(.secondary)
             }
             .padding(.top, 4)
         }
@@ -154,7 +154,7 @@ struct AIAssistantView: View {
                 } label: {
                     Label(localizationManager.text("common.back"), systemImage: "chevron.left")
                 }
-                .buttonStyle(.bordered)
+                .orchestranaButton(.secondary)
 
                 Spacer()
             }
@@ -207,9 +207,11 @@ struct AIAssistantView: View {
                     displayedComponents: [.date]
                 )
 
-                Stepper(value: $estimatedHours, in: 1...40) {
-                    Text(localizationManager.format("tasks.ai_plan.estimated_hours_value", estimatedHours))
-                }
+                OrchestranaStepControl(
+                    value: $estimatedHours,
+                    in: 1...40,
+                    valueText: { localizationManager.format("tasks.ai_plan.estimated_hours_value", $0) }
+                )
             }
 
             if let errorMessage, !errorMessage.isEmpty {
@@ -222,7 +224,7 @@ struct AIAssistantView: View {
                 Button(localizationManager.text("common.cancel")) {
                     onClose()
                 }
-                .buttonStyle(.bordered)
+                .orchestranaButton(.secondary)
 
                 Spacer()
 
@@ -244,7 +246,7 @@ struct AIAssistantView: View {
                         Text(buttonTitle(for: action))
                     }
                 }
-                .buttonStyle(.borderedProminent)
+                .orchestranaButton(.primary)
                 .disabled(isLoading || (action.requiresTaskSelection && selectedTaskIDs.isEmpty))
             }
         }

--- a/macos/Pomodoro/Pomodoro/AppAppearance.swift
+++ b/macos/Pomodoro/Pomodoro/AppAppearance.swift
@@ -130,6 +130,513 @@ enum AppearanceSurfaceLevel {
     case overlay
 }
 
+enum OrchestranaButtonVariant {
+    case primary
+    case secondary
+    case subtle
+    case quiet
+    case icon
+    case destructive
+}
+
+struct OrchestranaButtonStyle: ButtonStyle {
+    let variant: OrchestranaButtonVariant
+    let minWidth: CGFloat?
+    let minHeight: CGFloat
+
+    init(
+        _ variant: OrchestranaButtonVariant = .secondary,
+        minWidth: CGFloat? = nil,
+        minHeight: CGFloat = 30
+    ) {
+        self.variant = variant
+        self.minWidth = minWidth
+        self.minHeight = minHeight
+    }
+
+    func makeBody(configuration: Configuration) -> some View {
+        OrchestranaButtonBody(
+            configuration: configuration,
+            variant: variant,
+            minWidth: minWidth,
+            minHeight: minHeight
+        )
+    }
+}
+
+private struct OrchestranaButtonBody: View {
+    let configuration: ButtonStyle.Configuration
+    let variant: OrchestranaButtonVariant
+    let minWidth: CGFloat?
+    let minHeight: CGFloat
+
+    @AppStorage(AppearanceMode.appStorageKey) private var appearanceModeRawValue = AppearanceMode.standard.rawValue
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.isEnabled) private var isEnabled
+    @State private var isHovering = false
+
+    private var appearanceMode: AppearanceMode {
+        AppearanceMode.resolved(from: appearanceModeRawValue)
+    }
+
+    var body: some View {
+        let shape = buttonShape
+
+        configuration.label
+            .font(labelFont)
+            .lineLimit(1)
+            .foregroundStyle(foregroundColor)
+            .padding(.horizontal, horizontalPadding)
+            .frame(minWidth: minWidth, minHeight: minHeight)
+            .contentShape(shape)
+            .background {
+                backgroundFill(shape)
+            }
+            .overlay {
+                shape.stroke(borderColor, lineWidth: borderWidth)
+            }
+            .shadow(color: shadowColor, radius: shadowRadius, x: 0, y: shadowYOffset)
+            .scaleEffect(pressScale)
+            .opacity(isEnabled ? 1.0 : 0.48)
+            .animation(reduceMotion ? nil : .easeOut(duration: 0.12), value: configuration.isPressed)
+            .animation(reduceMotion ? nil : .easeOut(duration: 0.12), value: isHovering)
+            .onHover { isHovering = $0 }
+    }
+
+    private var buttonShape: RoundedRectangle {
+        RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+    }
+
+    private var cornerRadius: CGFloat {
+        variant == .icon ? 7 : 8
+    }
+
+    private var horizontalPadding: CGFloat {
+        switch variant {
+        case .icon:
+            return 7
+        case .subtle, .quiet:
+            return 10
+        default:
+            return 12
+        }
+    }
+
+    private var labelFont: Font {
+        switch variant {
+        case .icon:
+            return .system(.body).weight(.medium)
+        default:
+            return .system(.subheadline).weight(.medium)
+        }
+    }
+
+    private var foregroundColor: Color {
+        switch variant {
+        case .primary:
+            return .white
+        case .destructive:
+            return isEnabled ? .red : .secondary
+        case .subtle, .quiet, .icon:
+            return .primary
+        case .secondary:
+            return appearanceMode.primaryTextColor(for: colorScheme)
+        }
+    }
+
+    @ViewBuilder
+    private func backgroundFill(_ shape: RoundedRectangle) -> some View {
+        switch variant {
+        case .primary:
+            shape.fill(Color.accentColor.opacity(isEnabled ? (configuration.isPressed ? 0.78 : 0.88) : 0.3))
+        case .destructive:
+            shape.fill(Color.red.opacity(backgroundOpacity(primary: 0.08, hover: 0.12, pressed: 0.16)))
+        case .subtle, .quiet:
+            shape.fill(Color.primary.opacity(backgroundOpacity(primary: 0.00, hover: 0.045, pressed: 0.075)))
+        case .icon:
+            if appearanceMode == .glass {
+                shape.fill(isHovering || configuration.isPressed ? .thinMaterial : .ultraThinMaterial)
+            } else {
+                shape.fill(Color.primary.opacity(backgroundOpacity(primary: 0.035, hover: 0.065, pressed: 0.095)))
+            }
+        case .secondary:
+            if appearanceMode == .glass {
+                shape.fill(.thinMaterial)
+            } else {
+                shape.fill(appearanceMode.surfaceColor(for: .inset, colorScheme: colorScheme))
+            }
+        }
+    }
+
+    private func backgroundOpacity(primary: Double, hover: Double, pressed: Double) -> Double {
+        if configuration.isPressed { return pressed }
+        if isHovering { return hover }
+        return primary
+    }
+
+    private var borderColor: Color {
+        switch variant {
+        case .primary:
+            return Color.white.opacity(isHovering ? 0.28 : 0.18)
+        case .destructive:
+            return Color.red.opacity(isHovering ? 0.3 : 0.18)
+        case .subtle, .quiet:
+            return isHovering ? appearanceMode.borderColor(for: colorScheme, isEmphasized: true) : .clear
+        case .icon, .secondary:
+            return appearanceMode.borderColor(for: colorScheme, isEmphasized: isHovering || configuration.isPressed)
+        }
+    }
+
+    private var borderWidth: CGFloat {
+        (variant == .subtle || variant == .quiet) && !isHovering ? 0 : 1
+    }
+
+    private var shadowColor: Color {
+        guard isEnabled else { return .clear }
+        switch variant {
+        case .primary:
+            return Color.black.opacity(colorScheme == .dark ? 0.16 : 0.08)
+        case .secondary:
+            return isHovering ? appearanceMode.shadowColor(for: colorScheme, isEmphasized: false) : .clear
+        default:
+            return .clear
+        }
+    }
+
+    private var shadowRadius: CGFloat {
+        switch variant {
+        case .primary:
+            return isHovering ? 4 : 2
+        case .secondary:
+            return isHovering ? 3 : 0
+        default:
+            return 0
+        }
+    }
+
+    private var shadowYOffset: CGFloat {
+        variant == .primary ? 1 : 1
+    }
+
+    private var pressScale: CGFloat {
+        guard isEnabled, !reduceMotion else { return 1.0 }
+        return configuration.isPressed ? 0.99 : 1.0
+    }
+}
+
+struct OrchestranaTextFieldStyle: TextFieldStyle {
+    @AppStorage(AppearanceMode.appStorageKey) private var appearanceModeRawValue = AppearanceMode.standard.rawValue
+    @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.isEnabled) private var isEnabled
+
+    func _body(configuration: TextField<Self._Label>) -> some View {
+        let appearanceMode = AppearanceMode.resolved(from: appearanceModeRawValue)
+        let shape = RoundedRectangle(cornerRadius: 9, style: .continuous)
+
+        configuration
+            .textFieldStyle(.plain)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 7)
+            .background {
+                if appearanceMode == .glass {
+                    shape.fill(.thinMaterial)
+                } else {
+                    shape.fill(appearanceMode.surfaceColor(for: .inset, colorScheme: colorScheme))
+                }
+            }
+            .overlay {
+                shape.stroke(appearanceMode.borderColor(for: colorScheme), lineWidth: 1)
+            }
+            .opacity(isEnabled ? 1.0 : 0.55)
+    }
+}
+
+struct OrchestranaSelectorOption<Value: Hashable>: Identifiable {
+    let id: String
+    let value: Value
+    let title: String
+    let subtitle: String?
+    let systemImage: String?
+
+    init(
+        _ title: String,
+        value: Value,
+        subtitle: String? = nil,
+        systemImage: String? = nil,
+        id: String? = nil
+    ) {
+        self.id = id ?? title
+        self.value = value
+        self.title = title
+        self.subtitle = subtitle
+        self.systemImage = systemImage
+    }
+}
+
+enum OrchestranaSelectorLayout {
+    case inline
+    case grid
+}
+
+struct OrchestranaSelector<Value: Hashable>: View {
+    let options: [OrchestranaSelectorOption<Value>]
+    @Binding var selection: Value
+    let layout: OrchestranaSelectorLayout
+    let minOptionWidth: CGFloat
+    let accessibilityLabel: String?
+
+    @AppStorage(AppearanceMode.appStorageKey) private var appearanceModeRawValue = AppearanceMode.standard.rawValue
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.colorScheme) private var colorScheme
+
+    init(
+        selection: Binding<Value>,
+        options: [OrchestranaSelectorOption<Value>],
+        layout: OrchestranaSelectorLayout = .inline,
+        minOptionWidth: CGFloat = 74,
+        accessibilityLabel: String? = nil
+    ) {
+        self._selection = selection
+        self.options = options
+        self.layout = layout
+        self.minOptionWidth = minOptionWidth
+        self.accessibilityLabel = accessibilityLabel
+    }
+
+    var body: some View {
+        let appearanceMode = AppearanceMode.resolved(from: appearanceModeRawValue)
+        let shape = RoundedRectangle(cornerRadius: 11, style: .continuous)
+
+        Group {
+            switch layout {
+            case .inline:
+                HStack(spacing: 4) {
+                    optionButtons
+                }
+            case .grid:
+                LazyVGrid(
+                    columns: [GridItem(.adaptive(minimum: minOptionWidth), spacing: 8)],
+                    alignment: .leading,
+                    spacing: 8
+                ) {
+                    optionButtons
+                }
+            }
+        }
+            .padding(3)
+            .background {
+                if appearanceMode == .glass {
+                    shape.fill(.ultraThinMaterial)
+                } else {
+                    shape.fill(appearanceMode.surfaceColor(for: .inset, colorScheme: colorScheme))
+                }
+            }
+            .overlay {
+                shape.stroke(appearanceMode.borderColor(for: colorScheme), lineWidth: 1)
+            }
+            .accessibilityElement(children: .contain)
+            .accessibilityLabel(accessibilityLabel ?? "")
+    }
+
+    @ViewBuilder
+    private var optionButtons: some View {
+        ForEach(options) { option in
+            selectorButton(for: option)
+        }
+    }
+
+    private func selectorButton(for option: OrchestranaSelectorOption<Value>) -> some View {
+        Button {
+            withAnimation(reduceMotion ? nil : .easeOut(duration: 0.12)) {
+                selection = option.value
+            }
+        } label: {
+            OrchestranaSelectorOptionLabel(
+                option: option,
+                isSelected: selection == option.value,
+                minWidth: minOptionWidth
+            )
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(option.title)
+        .accessibilityAddTraits(selection == option.value ? .isSelected : [])
+    }
+}
+
+private struct OrchestranaSelectorOptionLabel<Value: Hashable>: View {
+    let option: OrchestranaSelectorOption<Value>
+    let isSelected: Bool
+    let minWidth: CGFloat
+
+    @AppStorage(AppearanceMode.appStorageKey) private var appearanceModeRawValue = AppearanceMode.standard.rawValue
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        let appearanceMode = AppearanceMode.resolved(from: appearanceModeRawValue)
+        let shape = RoundedRectangle(cornerRadius: 8, style: .continuous)
+
+        VStack(alignment: .center, spacing: option.subtitle == nil ? 0 : 2) {
+            HStack(spacing: 6) {
+                if let systemImage = option.systemImage {
+                    Image(systemName: systemImage)
+                        .font(.system(.caption, weight: .semibold))
+                }
+                Text(option.title)
+                    .font(.system(.subheadline, weight: .medium))
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.8)
+            }
+
+            if let subtitle = option.subtitle {
+                Text(subtitle)
+                    .font(.caption2)
+                    .foregroundStyle(isSelected ? Color.white.opacity(0.82) : appearanceMode.secondaryTextColor(for: colorScheme))
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.8)
+            }
+        }
+        .foregroundStyle(isSelected ? .white : .primary)
+        .padding(.horizontal, 10)
+        .padding(.vertical, option.subtitle == nil ? 6 : 7)
+        .frame(minWidth: minWidth, minHeight: option.subtitle == nil ? 28 : 42)
+        .background {
+            if isSelected {
+                shape.fill(Color.accentColor.opacity(0.86))
+            } else {
+                shape.fill(Color.primary.opacity(0.001))
+            }
+        }
+        .overlay {
+            shape.stroke(
+                isSelected ? Color.white.opacity(0.16) : Color.clear,
+                lineWidth: 1
+            )
+        }
+    }
+}
+
+struct OrchestranaStepControl: View {
+    @Binding var value: Int
+    let range: ClosedRange<Int>
+    let step: Int
+    let valueText: (Int) -> String
+    let onChange: (() -> Void)?
+
+    @Environment(\.isEnabled) private var isEnabled
+
+    init(
+        value: Binding<Int>,
+        in range: ClosedRange<Int>,
+        step: Int = 1,
+        valueText: @escaping (Int) -> String,
+        onChange: (() -> Void)? = nil
+    ) {
+        self._value = value
+        self.range = range
+        self.step = step
+        self.valueText = valueText
+        self.onChange = onChange
+    }
+
+    var body: some View {
+        HStack(spacing: 6) {
+            Button {
+                adjust(by: -step)
+            } label: {
+                Image(systemName: "minus")
+                    .frame(width: 14, height: 14)
+            }
+            .orchestranaButton(.icon, minWidth: 28, minHeight: 28)
+            .disabled(value <= range.lowerBound)
+            .help("Decrease")
+
+            Text(valueText(value))
+                .font(.system(.subheadline).monospacedDigit())
+                .foregroundStyle(isEnabled ? .primary : .secondary)
+                .lineLimit(1)
+                .minimumScaleFactor(0.8)
+                .frame(minWidth: 92)
+
+            Button {
+                adjust(by: step)
+            } label: {
+                Image(systemName: "plus")
+                    .frame(width: 14, height: 14)
+            }
+            .orchestranaButton(.icon, minWidth: 28, minHeight: 28)
+            .disabled(value >= range.upperBound)
+            .help("Increase")
+        }
+        .onChange(of: value) { _, _ in
+            onChange?()
+        }
+    }
+
+    private func adjust(by delta: Int) {
+        value = min(max(value + delta, range.lowerBound), range.upperBound)
+    }
+}
+
+struct OrchestranaControlGroup<Content: View>: View {
+    let content: Content
+
+    @AppStorage(AppearanceMode.appStorageKey) private var appearanceModeRawValue = AppearanceMode.standard.rawValue
+
+    init(@ViewBuilder content: () -> Content) {
+        self.content = content()
+    }
+
+    var body: some View {
+        let appearanceMode = AppearanceMode.resolved(from: appearanceModeRawValue)
+
+        HStack(spacing: 8) {
+            content
+        }
+        .padding(4)
+        .appRoundedSurface(
+            mode: appearanceMode,
+            cornerRadius: 12,
+            glassMaterial: .ultraThinMaterial,
+            standardLevel: .inset,
+            isEmphasized: false,
+            showsShadow: false
+        )
+    }
+}
+
+struct OrchestranaFormRow<Control: View>: View {
+    let title: String
+    let detail: String?
+    let control: Control
+
+    init(
+        title: String,
+        detail: String? = nil,
+        @ViewBuilder control: () -> Control
+    ) {
+        self.title = title
+        self.detail = detail
+        self.control = control()
+    }
+
+    var body: some View {
+        HStack(alignment: .center, spacing: 16) {
+            VStack(alignment: .leading, spacing: 3) {
+                Text(title)
+                    .font(.system(.body, weight: .medium))
+                if let detail {
+                    Text(detail)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            Spacer(minLength: 16)
+            control
+        }
+    }
+}
+
 private struct AppRoundedSurfaceModifier: ViewModifier {
     @Environment(\.colorScheme) private var colorScheme
     let mode: AppearanceMode
@@ -182,6 +689,18 @@ extension View {
                 showsShadow: showsShadow
             )
         )
+    }
+
+    func orchestranaButton(
+        _ variant: OrchestranaButtonVariant = .secondary,
+        minWidth: CGFloat? = nil,
+        minHeight: CGFloat = 30
+    ) -> some View {
+        buttonStyle(OrchestranaButtonStyle(variant, minWidth: minWidth, minHeight: minHeight))
+    }
+
+    func orchestranaTextField() -> some View {
+        textFieldStyle(OrchestranaTextFieldStyle())
     }
 }
 

--- a/macos/Pomodoro/Pomodoro/CalendarView.swift
+++ b/macos/Pomodoro/Pomodoro/CalendarView.swift
@@ -107,6 +107,14 @@ struct CalendarView: View {
             }
         }
     }
+
+    private var calendarViewOptions: [OrchestranaSelectorOption<ViewType>] {
+        [
+            OrchestranaSelectorOption(localizationManager.text("calendar.view.day"), value: .day, systemImage: "calendar.day.timeline.left"),
+            OrchestranaSelectorOption(localizationManager.text("calendar.view.week"), value: .week, systemImage: "calendar"),
+            OrchestranaSelectorOption(localizationManager.text("calendar.view.month"), value: .month, systemImage: "square.grid.3x3")
+        ]
+    }
     
     var body: some View {
         VStack(spacing: 0) {
@@ -241,12 +249,12 @@ struct CalendarView: View {
                     }
 
                     HStack(spacing: 12) {
-                        Picker(localizationManager.text("calendar.view"), selection: $selectedView) {
-                            Text(localizationManager.text("calendar.view.day")).tag(ViewType.day)
-                            Text(localizationManager.text("calendar.view.week")).tag(ViewType.week)
-                            Text(localizationManager.text("calendar.view.month")).tag(ViewType.month)
-                        }
-                        .pickerStyle(.segmented)
+                        OrchestranaSelector(
+                            selection: $selectedView,
+                            options: calendarViewOptions,
+                            minOptionWidth: 76,
+                            accessibilityLabel: localizationManager.text("calendar.view")
+                        )
                         .frame(maxWidth: 260)
                         .onChange(of: selectedView) { _, _ in
                             Task { await loadEvents() }
@@ -271,7 +279,7 @@ struct CalendarView: View {
                         } label: {
                             Label(localizationManager.text("calendar.add_event"), systemImage: "plus")
                         }
-                        .buttonStyle(.borderedProminent)
+                        .orchestranaButton(.primary)
 
                         Button {
                             if !featureGate.canUseCloudProxyAI {
@@ -286,9 +294,9 @@ struct CalendarView: View {
                                 showAIAssistant = true
                             }
                         } label: {
-                            Label(localizationManager.text("tasks.ai_assistant.button"), systemImage: "sparkles")
+                            Label(localizationManager.text("tasks.ai_assistant.button"), systemImage: "calendar.badge.clock")
                         }
-                        .buttonStyle(.bordered)
+                        .orchestranaButton(.secondary)
                         .help(localizationManager.text("calendar.ai_assistant.reschedule_description"))
 
                         Button {
@@ -296,7 +304,7 @@ struct CalendarView: View {
                         } label: {
                             Label(localizationManager.text("common.refresh"), systemImage: "arrow.clockwise")
                         }
-                        .buttonStyle(.bordered)
+                        .orchestranaButton(.secondary)
                     }
 
                     if selectedEventIDs.count > 1 {
@@ -361,7 +369,7 @@ struct CalendarView: View {
                 Label(localizationManager.text("calendar.request_access"), systemImage: "calendar")
                     .font(.headline)
             }
-            .buttonStyle(.borderedProminent)
+            .orchestranaButton(.primary)
             .controlSize(.large)
         }
         .padding(48)
@@ -394,7 +402,7 @@ struct CalendarView: View {
             Button(localizationManager.text("calendar.reschedule.undo")) {
                 revertCalendarReschedule()
             }
-            .buttonStyle(.bordered)
+            .orchestranaButton(.secondary)
             .controlSize(.small)
         }
         .padding(.horizontal, 16)
@@ -1243,7 +1251,7 @@ struct CalendarView: View {
                 } label: {
                     Label(localizationManager.text("common.move"), systemImage: "arrow.right.circle")
                 }
-                .buttonStyle(.bordered)
+                .orchestranaButton(.secondary)
                 .disabled(editableSelection.isEmpty)
                 
                 Button(role: .destructive) {
@@ -1251,8 +1259,7 @@ struct CalendarView: View {
                 } label: {
                     Label(localizationManager.text("common.delete"), systemImage: "trash")
                 }
-                .buttonStyle(.borderedProminent)
-                .tint(.red)
+                .orchestranaButton(.destructive)
                 .disabled(editableSelection.isEmpty)
             }
             
@@ -1642,18 +1649,23 @@ private struct AddEventSheet: View {
             
             VStack(alignment: .leading, spacing: 8) {
                 TextField(localizationManager.text("common.title"), text: $title)
-                    .textFieldStyle(.roundedBorder)
+                    .orchestranaTextField()
                 
                 DatePicker(localizationManager.text("common.start"), selection: $startDate)
                 
                 HStack {
                     Text(localizationManager.text("common.duration"))
                     Spacer()
-                    Stepper(localizationManager.format("common.duration_minutes_format", durationMinutes), value: $durationMinutes, in: 15...480, step: 15)
+                    OrchestranaStepControl(
+                        value: $durationMinutes,
+                        in: 15...480,
+                        step: 15,
+                        valueText: { localizationManager.format("common.duration_minutes_format", $0) }
+                    )
                 }
                 
                 TextField(localizationManager.text("common.notes_optional"), text: $notes, axis: .vertical)
-                    .textFieldStyle(.roundedBorder)
+                    .orchestranaTextField()
             }
             
             if let errorMessage {
@@ -1665,14 +1677,14 @@ private struct AddEventSheet: View {
             
             HStack {
                 Button(localizationManager.text("common.cancel"), action: onCancel)
-                    .buttonStyle(.bordered)
+                    .orchestranaButton(.secondary)
                 
                 Spacer()
                 
                 Button(localizationManager.text("common.save")) {
                     onSave()
                 }
-                .buttonStyle(.borderedProminent)
+                .orchestranaButton(.primary)
                 .disabled(title.isEmpty)
             }
         }
@@ -1775,7 +1787,7 @@ private struct EventTaskDetailSheet: View {
                 }
                 Spacer()
                 Button(localizationManager.text("common.close"), action: onClose)
-                    .buttonStyle(.bordered)
+                    .orchestranaButton(.secondary)
             }
 
             if let notes = event.wrappedValue.notes, !notes.isEmpty {
@@ -1802,18 +1814,18 @@ private struct EventTaskDetailSheet: View {
                                 Text(localizationManager.text("calendar.event_tasks.generate_ai"))
                             }
                         }
-                        .buttonStyle(.bordered)
+                        .orchestranaButton(.secondary)
                         .disabled(isGenerating)
                     }
 
                     if canInteractWithEventTasks {
                         HStack(spacing: 8) {
                             TextField(localizationManager.text("calendar.event_tasks.add_placeholder"), text: $manualTaskTitle)
-                                .textFieldStyle(.roundedBorder)
+                                .orchestranaTextField()
                             Button(localizationManager.text("calendar.event_tasks.add_button")) {
                                 Task { await addManualTask(event: event) }
                             }
-                            .buttonStyle(.borderedProminent)
+                            .orchestranaButton(.primary)
                         }
                     } else {
                         lockedEventTasksView
@@ -1871,7 +1883,7 @@ private struct EventTaskDetailSheet: View {
                                         )
                                         todoStore.addItem(todo)
                                     }
-                                    .buttonStyle(.borderless)
+                                    .orchestranaButton(.subtle)
                                 }
                             }
                             .onDelete { offsets in
@@ -1930,7 +1942,7 @@ private struct EventTaskDetailSheet: View {
             Button(localizationManager.text("tasks.ai_assistant.upgrade")) {
                 presentUpgrade(requiredTier: .plus, messageKey: "calendar.event_tasks.plus_required")
             }
-            .buttonStyle(.bordered)
+            .orchestranaButton(.secondary)
         }
     }
 

--- a/macos/Pomodoro/Pomodoro/CloudSettingsSection.swift
+++ b/macos/Pomodoro/Pomodoro/CloudSettingsSection.swift
@@ -89,7 +89,7 @@ struct CloudSettingsSection: View {
                     await authViewModel.signOut()
                 }
             }
-            .buttonStyle(.bordered)
+            .orchestranaButton(.secondary)
             .disabled(authViewModel.isAuthenticating || authViewModel.isDeletingAccount)
 
             Divider()
@@ -112,7 +112,7 @@ struct CloudSettingsSection: View {
                         Text(localizationManager.text("settings.account.delete_account_button"))
                     }
                 }
-                .buttonStyle(.bordered)
+                .orchestranaButton(.destructive)
                 .disabled(authViewModel.isAuthenticating || authViewModel.isDeletingAccount)
             }
 
@@ -349,13 +349,13 @@ struct EmailLoginView: View {
                 .foregroundStyle(.secondary)
 
             TextField(localizationManager.text("auth.email.placeholder"), text: $email)
-                .textFieldStyle(.roundedBorder)
+                .orchestranaTextField()
                 .textContentType(.emailAddress)
                 .autocorrectionDisabled()
                 .disabled(authViewModel.isAuthenticating)
 
             SecureField(localizationManager.text("auth.password.placeholder"), text: $password)
-                .textFieldStyle(.roundedBorder)
+                .orchestranaTextField()
                 .textContentType(.password)
                 .disabled(authViewModel.isAuthenticating)
 
@@ -384,7 +384,7 @@ struct EmailLoginView: View {
                     }
                 }
             }
-            .buttonStyle(.borderedProminent)
+            .orchestranaButton(.primary)
             .disabled(authViewModel.isAuthenticating || !canSubmit)
 
             Button(localizationManager.text("auth.create_account")) {
@@ -402,7 +402,7 @@ struct EmailLoginView: View {
                     }
                 }
             }
-            .buttonStyle(.bordered)
+            .orchestranaButton(.secondary)
             .disabled(authViewModel.isAuthenticating || !canSubmit)
 
             HStack {
@@ -414,7 +414,7 @@ struct EmailLoginView: View {
                     passwordResetErrorMessage = nil
                     showingPasswordResetSheet = true
                 }
-                .buttonStyle(.link)
+                .orchestranaButton(.subtle)
                 .disabled(authViewModel.isAuthenticating)
             }
         }
@@ -466,7 +466,7 @@ struct EmailLoginView: View {
                     .foregroundStyle(.secondary)
 
                 TextField(localizationManager.text("auth.email.placeholder"), text: $passwordResetEmail)
-                    .textFieldStyle(.roundedBorder)
+                    .orchestranaTextField()
                     .textContentType(.emailAddress)
                     .autocorrectionDisabled()
                     .disabled(isSendingPasswordReset)
@@ -489,7 +489,7 @@ struct EmailLoginView: View {
                     Button(localizationManager.text("common.cancel")) {
                         showingPasswordResetSheet = false
                     }
-                    .buttonStyle(.bordered)
+                    .orchestranaButton(.secondary)
 
                     Button(localizationManager.text("auth.password_reset.send")) {
                         Task { @MainActor in
@@ -506,7 +506,7 @@ struct EmailLoginView: View {
                             isSendingPasswordReset = false
                         }
                     }
-                    .buttonStyle(.borderedProminent)
+                    .orchestranaButton(.primary)
                         .disabled(isSendingPasswordReset || passwordResetEmail.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
                 }
             }
@@ -569,7 +569,7 @@ struct LoginSheetView: View {
                 Button(localizationManager.text("common.close")) {
                     dismiss()
                 }
-                .buttonStyle(.bordered)
+                .orchestranaButton(.secondary)
             }
         }
         .padding(20)

--- a/macos/Pomodoro/Pomodoro/ContentView.swift
+++ b/macos/Pomodoro/Pomodoro/ContentView.swift
@@ -23,6 +23,8 @@ struct ContentView: View {
             }
         }
         .animation(.easeInOut(duration: 0.22), value: onboardingState.isPresented)
+        .buttonStyle(OrchestranaButtonStyle(.secondary))
+        .textFieldStyle(OrchestranaTextFieldStyle())
     }
 }
 

--- a/macos/Pomodoro/Pomodoro/FlowModeView.swift
+++ b/macos/Pomodoro/Pomodoro/FlowModeView.swift
@@ -633,7 +633,7 @@ struct FlowModeView: View {
                             Button(localizationManager.text("common.cancel")) {
                                 flowWindowManager.dismissPremiumPreview()
                             }
-                            .buttonStyle(.bordered)
+                            .orchestranaButton(.secondary)
 
                             Spacer()
 
@@ -644,7 +644,7 @@ struct FlowModeView: View {
                                     await subscriptionStore.purchase(product)
                                 }
                             }
-                            .buttonStyle(.borderedProminent)
+                            .orchestranaButton(.primary)
                             .disabled(isPreviewPurchaseButtonDisabled)
                         }
                     }

--- a/macos/Pomodoro/Pomodoro/MainWindowView.swift
+++ b/macos/Pomodoro/Pomodoro/MainWindowView.swift
@@ -202,24 +202,20 @@ struct MainWindowView: View {
                     // Flow-mode-inspired gentle tick dissolve to keep time feeling fluid.
                     .animation(mainTimerUpdateAnimation, value: appState.pomodoro.remainingSeconds)
                     .animation(timerStateAnimation, value: pomodoroStatePulse)
-                Text(languageManager.format("timer.state_format", labelForPomodoroState(appState.pomodoro.state)))
-                    .font(.system(size: 15, weight: .medium, design: .default))
-                    .foregroundStyle(.secondary)
+                timerStateBadge(for: appState.pomodoro.state)
             }
 
             VStack(alignment: .leading, spacing: 8) {
                 Text(languageManager.text("timer.preset"))
                     .font(.system(.headline, design: .rounded))
                     .foregroundStyle(.secondary)
-                Picker(languageManager.text("timer.preset"), selection: presetSelectionBinding) {
-                    ForEach(Preset.builtIn) { preset in
-                        Text(preset.name)
-                            .tag(PresetSelection.preset(preset))
-                    }
-                    Text(languageManager.text("timer.custom"))
-                        .tag(PresetSelection.custom)
-                }
-                .pickerStyle(.segmented)
+                OrchestranaSelector(
+                    selection: presetSelectionBinding,
+                    options: presetSelectorOptions(),
+                    layout: .grid,
+                    minOptionWidth: 96,
+                    accessibilityLabel: languageManager.text("timer.preset")
+                )
             }
 
             VStack(alignment: .leading, spacing: 8) {
@@ -265,19 +261,19 @@ struct MainWindowView: View {
 
             HStack(spacing: 10) {
                 let actions = pomodoroActions(for: appState.pomodoro.state)
-                ActionButton(languageManager.text("common.start"), isEnabled: actions.canStart) {
+                ActionButton(languageManager.text("common.start"), systemImage: "play.fill", variant: .primary, isEnabled: actions.canStart) {
                     appState.pomodoro.start()
                 }
-                ActionButton(languageManager.text("common.pause"), isEnabled: actions.canPause) {
+                ActionButton(languageManager.text("common.pause"), systemImage: "pause.fill", isEnabled: actions.canPause) {
                     appState.pomodoro.pause()
                 }
-                ActionButton(languageManager.text("common.resume"), isEnabled: actions.canResume) {
+                ActionButton(languageManager.text("common.resume"), systemImage: "play.fill", variant: .primary, isEnabled: actions.canResume) {
                     appState.pomodoro.resume()
                 }
-                ActionButton(languageManager.text("common.reset")) {
+                ActionButton(languageManager.text("common.reset"), systemImage: "arrow.counterclockwise") {
                     appState.pomodoro.reset()
                 }
-                ActionButton(languageManager.text("timer.skip_break"), isEnabled: actions.canSkipBreak) {
+                ActionButton(languageManager.text("timer.skip_break"), systemImage: "forward.end.fill", variant: .destructive, isEnabled: actions.canSkipBreak) {
                     appState.pomodoro.skipBreak()
                 }
                 Button {
@@ -292,10 +288,10 @@ struct MainWindowView: View {
                             Text("Your Plans")
                         }
                     } else {
-                        Text("Your Plans")
+                        Label("Your Plans", systemImage: "list.bullet.rectangle")
                     }
                 }
-                .buttonStyle(.borderedProminent)
+                .orchestranaButton(.secondary, minWidth: 112)
                 .disabled(isCheckingPlans)
             }
 
@@ -330,9 +326,7 @@ struct MainWindowView: View {
                                 Text(formattedTime(appState.pomodoro.remainingSeconds))
                                     .font(.system(size: 68, weight: .heavy, design: .rounded).monospacedDigit())
                                     .contentTransition(.numericText())
-                                Text(languageManager.format("timer.state_format", labelForPomodoroState(appState.pomodoro.state)))
-                                    .font(.subheadline.weight(.medium))
-                                    .foregroundStyle(.secondary)
+                                timerStateBadge(for: appState.pomodoro.state)
                             }
 
                             Spacer()
@@ -350,32 +344,32 @@ struct MainWindowView: View {
                                             Text("Your Plans")
                                         }
                                     } else {
-                                        Text("Your Plans")
+                                        Label("Your Plans", systemImage: "list.bullet.rectangle")
                                     }
                                 }
-                                .buttonStyle(.borderedProminent)
+                                .orchestranaButton(.secondary, minWidth: 112)
                                 .disabled(isCheckingPlans)
                             }
                         }
 
                         HStack(spacing: 10) {
                             let actions = pomodoroActions(for: appState.pomodoro.state)
-                            ActionButton(languageManager.text("common.start"), isEnabled: actions.canStart) {
-                                startDashboardPomodoro()
-                            }
-                            ActionButton(languageManager.text("common.pause"), isEnabled: actions.canPause) {
-                                appState.pomodoro.pause()
-                            }
-                            ActionButton(languageManager.text("common.resume"), isEnabled: actions.canResume) {
-                                appState.pomodoro.resume()
-                            }
-                            ActionButton(languageManager.text("common.reset")) {
-                                appState.resetPomodoro()
-                                previewDashboardPomodoroIfIdle()
-                            }
-                            ActionButton(languageManager.text("timer.skip_break"), isEnabled: actions.canSkipBreak) {
-                                appState.pomodoro.skipBreak()
-                            }
+                                ActionButton(languageManager.text("common.start"), systemImage: "play.fill", variant: .primary, isEnabled: actions.canStart) {
+                                    startDashboardPomodoro()
+                                }
+                                ActionButton(languageManager.text("common.pause"), systemImage: "pause.fill", isEnabled: actions.canPause) {
+                                    appState.pomodoro.pause()
+                                }
+                                ActionButton(languageManager.text("common.resume"), systemImage: "play.fill", variant: .primary, isEnabled: actions.canResume) {
+                                    appState.pomodoro.resume()
+                                }
+                                ActionButton(languageManager.text("common.reset"), systemImage: "arrow.counterclockwise") {
+                                    appState.resetPomodoro()
+                                    previewDashboardPomodoroIfIdle()
+                                }
+                                ActionButton(languageManager.text("timer.skip_break"), systemImage: "forward.end.fill", variant: .destructive, isEnabled: actions.canSkipBreak) {
+                                    appState.pomodoro.skipBreak()
+                                }
                         }
 
                         dashboardPomodoroConfigurationPanel
@@ -579,9 +573,7 @@ struct MainWindowView: View {
                     .contentTransition(.numericText())
                     .animation(mainTimerUpdateAnimation, value: appState.countdown.remainingSeconds)
                     .animation(timerStateAnimation, value: countdownStatePulse)
-                Text(languageManager.format("timer.state_format", labelForPomodoroState(appState.countdown.state)))
-                    .font(.system(size: 15, weight: .medium, design: .default))
-                    .foregroundStyle(.secondary)
+                timerStateBadge(for: appState.countdown.state)
             }
 
             VStack(alignment: .leading, spacing: 8) {
@@ -601,13 +593,13 @@ struct MainWindowView: View {
 
             HStack(spacing: 10) {
                 let actions = countdownActions(for: appState.countdown.state)
-                ActionButton(languageManager.text("common.start"), isEnabled: actions.canStart) {
+                ActionButton(languageManager.text("common.start"), variant: .primary, isEnabled: actions.canStart) {
                     appState.countdown.start()
                 }
                 ActionButton(languageManager.text("common.pause"), isEnabled: actions.canPause) {
                     appState.countdown.pause()
                 }
-                ActionButton(languageManager.text("common.resume"), isEnabled: actions.canResume) {
+                ActionButton(languageManager.text("common.resume"), variant: .primary, isEnabled: actions.canResume) {
                     appState.countdown.resume()
                 }
                 ActionButton(languageManager.text("common.reset")) {
@@ -736,7 +728,7 @@ struct MainWindowView: View {
                             sidebarSelection = .tasks
                         }
                     }
-                    .buttonStyle(.bordered)
+                    .orchestranaButton(.secondary)
                 }
             }
 
@@ -754,7 +746,7 @@ struct MainWindowView: View {
                             sidebarSelection = .calendar
                         }
                     }
-                    .buttonStyle(.bordered)
+                    .orchestranaButton(.secondary)
                 }
             }
 
@@ -802,7 +794,7 @@ struct MainWindowView: View {
                             sidebarSelection = .workspace
                         }
                     }
-                    .buttonStyle(.bordered)
+                    .orchestranaButton(.secondary)
                 }
             }
 
@@ -825,7 +817,7 @@ struct MainWindowView: View {
 
     private var insightEmptyStateCallToAction: some View {
         HStack(alignment: .top, spacing: 16) {
-            Image(systemName: "sparkles.rectangle.stack")
+            Image(systemName: "chart.line.uptrend.xyaxis")
                 .font(.system(size: 18, weight: .semibold))
                 .foregroundStyle(currentAppearanceMode.secondaryTextColor(for: colorScheme))
                 .frame(width: 36, height: 36)
@@ -853,7 +845,7 @@ struct MainWindowView: View {
                     sidebarSelection = .dashboard
                 }
             }
-            .buttonStyle(.borderedProminent)
+            .orchestranaButton(.primary)
         }
     }
 
@@ -871,7 +863,7 @@ struct MainWindowView: View {
                     Text("Generate Overview")
                 }
             }
-            .buttonStyle(.bordered)
+            .orchestranaButton(.secondary)
             .disabled(isInsightHubLoading)
 
             Button("Run Deep Analysis") {
@@ -879,7 +871,7 @@ struct MainWindowView: View {
                     await runInsightDeepAnalysis()
                 }
             }
-            .buttonStyle(.bordered)
+            .orchestranaButton(.secondary)
             .disabled(isInsightHubLoading)
 
             Menu("Explain Metric") {
@@ -964,7 +956,7 @@ struct MainWindowView: View {
     private var settingsSidebar: some View {
         VStack(alignment: .leading, spacing: 16) {
             TextField("Search Settings", text: $settingsSearchText)
-                .textFieldStyle(.roundedBorder)
+                .orchestranaTextField()
 
             VStack(alignment: .leading, spacing: 8) {
                 ForEach(filteredSettingsPanes) { pane in
@@ -1055,15 +1047,12 @@ struct MainWindowView: View {
         ) {
             VStack(alignment: .leading, spacing: 18) {
                 settingsLabeledControl(title: "Language", description: "Choose how the app should present text.") {
-                    Picker(languageManager.text("settings.language.picker.label"), selection: $languageManager.currentLanguage) {
-                        Text(languageManager.text("settings.language.system"))
-                            .tag(LanguageManager.AppLanguage.auto)
-                        Text(languageManager.text("settings.language.english"))
-                            .tag(LanguageManager.AppLanguage.english)
-                        Text(languageManager.text("settings.language.chinese"))
-                            .tag(LanguageManager.AppLanguage.chinese)
-                    }
-                    .pickerStyle(.segmented)
+                    OrchestranaSelector(
+                        selection: $languageManager.currentLanguage,
+                        options: languageSelectorOptions,
+                        minOptionWidth: 82,
+                        accessibilityLabel: languageManager.text("settings.language.picker.label")
+                    )
                     .frame(maxWidth: 320)
                 }
 
@@ -1074,7 +1063,7 @@ struct MainWindowView: View {
                     Button(languageManager.text("settings.onboarding.reopen")) {
                         onboardingState.reopen()
                     }
-                    .buttonStyle(.bordered)
+                    .orchestranaButton(.secondary)
                 }
             }
         }
@@ -1090,12 +1079,12 @@ struct MainWindowView: View {
                     title: languageManager.text("settings.appearance.font.title"),
                     description: languageManager.text("settings.appearance.font.description")
                 ) {
-                    Picker(languageManager.text("settings.appearance.font.title"), selection: $appTypography.style) {
-                        ForEach(AppTypography.Style.allCases) { style in
-                            Text(style.title(using: languageManager)).tag(style)
-                        }
-                    }
-                    .pickerStyle(.segmented)
+                    OrchestranaSelector(
+                        selection: $appTypography.style,
+                        options: typographySelectorOptions,
+                        minOptionWidth: 112,
+                        accessibilityLabel: languageManager.text("settings.appearance.font.title")
+                    )
                     .frame(maxWidth: 320)
                 }
 
@@ -1105,12 +1094,13 @@ struct MainWindowView: View {
                     title: languageManager.text("settings.appearance.mode.title"),
                     description: languageManager.text("settings.appearance.mode.description")
                 ) {
-                    Picker(languageManager.text("settings.appearance.mode.title"), selection: appearanceModeSelection) {
-                        ForEach(AppearanceMode.allCases) { mode in
-                            Text(title(for: mode)).tag(mode)
-                        }
-                    }
-                    .pickerStyle(.radioGroup)
+                    OrchestranaSelector(
+                        selection: appearanceModeSelection,
+                        options: appearanceModeSelectorOptions,
+                        minOptionWidth: 104,
+                        accessibilityLabel: languageManager.text("settings.appearance.mode.title")
+                    )
+                    .frame(maxWidth: 260)
                 }
 
                 Divider()
@@ -1145,21 +1135,57 @@ struct MainWindowView: View {
         }
     }
 
+    private var languageSelectorOptions: [OrchestranaSelectorOption<LanguageManager.AppLanguage>] {
+        [
+            OrchestranaSelectorOption(languageManager.text("settings.language.system"), value: .auto, systemImage: "globe"),
+            OrchestranaSelectorOption(languageManager.text("settings.language.english"), value: .english, systemImage: "textformat"),
+            OrchestranaSelectorOption(languageManager.text("settings.language.chinese"), value: .chinese, systemImage: "character")
+        ]
+    }
+
+    private var typographySelectorOptions: [OrchestranaSelectorOption<AppTypography.Style>] {
+        AppTypography.Style.allCases.map { style in
+            OrchestranaSelectorOption(style.title(using: languageManager), value: style)
+        }
+    }
+
+    private var appearanceModeSelectorOptions: [OrchestranaSelectorOption<AppearanceMode>] {
+        AppearanceMode.allCases.map { mode in
+            OrchestranaSelectorOption(title(for: mode), value: mode)
+        }
+    }
+
+    private var notificationDeliveryOptions: [OrchestranaSelectorOption<NotificationDeliveryStyle>] {
+        NotificationDeliveryStyle.allCases.map { style in
+            OrchestranaSelectorOption(style.title, value: style)
+        }
+    }
+
+    private var notificationPreferenceOptions: [OrchestranaSelectorOption<NotificationPreference>] {
+        NotificationPreference.allCases.map { preference in
+            OrchestranaSelectorOption(preference.title, value: preference)
+        }
+    }
+
+    private var reminderPreferenceOptions: [OrchestranaSelectorOption<ReminderPreference>] {
+        ReminderPreference.allCases.map { preference in
+            OrchestranaSelectorOption(preference.title, value: preference)
+        }
+    }
+
     private var settingsTimerPresetModule: some View {
         SettingsModuleCard(
             title: "Timer & Focus",
             description: "Set the default Pomodoro rhythm used when the dashboard is not overriding the current session."
         ) {
             settingsLabeledControl(title: languageManager.text("timer.preset"), description: "Switch between built-in focus presets or a custom schedule.") {
-                Picker(languageManager.text("timer.preset"), selection: presetSelectionBinding) {
-                    ForEach(Preset.builtIn) { preset in
-                        Text(preset.name)
-                            .tag(PresetSelection.preset(preset))
-                    }
-                    Text(languageManager.text("timer.custom"))
-                        .tag(PresetSelection.custom)
-                }
-                .pickerStyle(.segmented)
+                OrchestranaSelector(
+                    selection: presetSelectionBinding,
+                    options: presetSelectorOptions(),
+                    layout: .grid,
+                    minOptionWidth: 104,
+                    accessibilityLabel: languageManager.text("timer.preset")
+                )
             }
         }
     }
@@ -1231,34 +1257,34 @@ struct MainWindowView: View {
         ) {
             VStack(alignment: .leading, spacing: 14) {
                 settingsLabeledControl(title: languageManager.text("main.delivery"), description: "Decide how timer alerts should reach you.") {
-                    Picker(languageManager.text("main.delivery"), selection: $appState.notificationDeliveryStyle) {
-                        ForEach(NotificationDeliveryStyle.allCases) { style in
-                            Text(style.title).tag(style)
-                        }
-                    }
-                    .pickerStyle(.segmented)
+                    OrchestranaSelector(
+                        selection: $appState.notificationDeliveryStyle,
+                        options: notificationDeliveryOptions,
+                        minOptionWidth: 112,
+                        accessibilityLabel: languageManager.text("main.delivery")
+                    )
                 }
 
                 Divider()
 
                 settingsLabeledControl(title: languageManager.text("settings.notifications.title"), description: "Control whether focus notifications are shown.") {
-                    Picker(languageManager.text("settings.notifications.title"), selection: $appState.notificationPreference) {
-                        ForEach(NotificationPreference.allCases) { preference in
-                            Text(preference.title).tag(preference)
-                        }
-                    }
-                    .pickerStyle(.segmented)
+                    OrchestranaSelector(
+                        selection: $appState.notificationPreference,
+                        options: notificationPreferenceOptions,
+                        minOptionWidth: 92,
+                        accessibilityLabel: languageManager.text("settings.notifications.title")
+                    )
                 }
 
                 Divider()
 
                 settingsLabeledControl(title: languageManager.text("main.reminder"), description: "Choose how reminder follow-ups should behave.") {
-                    Picker(languageManager.text("main.reminder"), selection: $appState.reminderPreference) {
-                        ForEach(ReminderPreference.allCases) { preference in
-                            Text(preference.title).tag(preference)
-                        }
-                    }
-                    .pickerStyle(.segmented)
+                    OrchestranaSelector(
+                        selection: $appState.reminderPreference,
+                        options: reminderPreferenceOptions,
+                        minOptionWidth: 112,
+                        accessibilityLabel: languageManager.text("main.reminder")
+                    )
                 }
             }
         }
@@ -1337,13 +1363,13 @@ struct MainWindowView: View {
                         Text("Restore & Sync Subscription")
                     }
                 }
-                .buttonStyle(.bordered)
+                .orchestranaButton(.secondary)
                 .disabled(subscriptionStore.isRestoring)
 
                 Button("Manage Subscription") {
                     showSettingsPlansSheet = true
                 }
-                .buttonStyle(.borderedProminent)
+                .orchestranaButton(.primary)
 
                 if let errorMessage = subscriptionStore.errorMessage, !errorMessage.isEmpty {
                     Text(errorMessage)
@@ -1398,7 +1424,7 @@ struct MainWindowView: View {
                     Button("Compare Plans") {
                         showSettingsPlansSheet = true
                     }
-                    .buttonStyle(.bordered)
+                    .orchestranaButton(.secondary)
                 }
             }
         }
@@ -1436,7 +1462,7 @@ struct MainWindowView: View {
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
             }
-            .buttonStyle(.bordered)
+            .orchestranaButton(.secondary)
         }
     }
 
@@ -1490,7 +1516,7 @@ struct MainWindowView: View {
             Spacer()
 
             Button(buttonTitle, action: action)
-                .buttonStyle(.bordered)
+                .orchestranaButton(.secondary)
         }
     }
 
@@ -1606,7 +1632,7 @@ struct MainWindowView: View {
                                 .font(.system(size: 16, weight: .semibold))
                                 .frame(width: 28, height: 28)
                         }
-                        .buttonStyle(.borderless)
+                        .orchestranaButton(.subtle)
                         .disabled(!appState.nowPlayingRouter.isAvailable)
 
                         Button {
@@ -1628,7 +1654,7 @@ struct MainWindowView: View {
                                 .font(.system(size: 16, weight: .semibold))
                                 .frame(width: 28, height: 28)
                         }
-                        .buttonStyle(.borderless)
+                        .orchestranaButton(.subtle)
                         .disabled(!appState.nowPlayingRouter.isAvailable)
                     }
                 }
@@ -1864,30 +1890,30 @@ struct MainWindowView: View {
                 Spacer(minLength: 0)
             }
 
-            HStack(spacing: 8) {
-                ForEach([25, 50, 90], id: \.self) { preset in
-                    Button("\(preset) min") {
-                        applyCountdownPreset(minutes: preset)
-                    }
-                    .buttonStyle(.bordered)
-                }
-            }
+            OrchestranaSelector(
+                selection: countdownPresetSelection,
+                options: [25, 50, 90].map {
+                    OrchestranaSelectorOption("\($0) min", value: $0, systemImage: "timer")
+                },
+                minOptionWidth: 78,
+                accessibilityLabel: "Countdown presets"
+            )
         }
     }
 
     private var countdownActionsRow: some View {
         HStack(spacing: 10) {
             let actions = countdownActions(for: appState.countdown.state)
-            ActionButton(languageManager.text("common.start"), isEnabled: actions.canStart) {
+            ActionButton(languageManager.text("common.start"), systemImage: "play.fill", variant: .primary, isEnabled: actions.canStart) {
                 appState.countdown.start()
             }
-            ActionButton(languageManager.text("common.pause"), isEnabled: actions.canPause) {
+            ActionButton(languageManager.text("common.pause"), systemImage: "pause.fill", isEnabled: actions.canPause) {
                 appState.countdown.pause()
             }
-            ActionButton(languageManager.text("common.resume"), isEnabled: actions.canResume) {
+            ActionButton(languageManager.text("common.resume"), systemImage: "play.fill", variant: .primary, isEnabled: actions.canResume) {
                 appState.countdown.resume()
             }
-            ActionButton(languageManager.text("common.reset")) {
+            ActionButton(languageManager.text("common.reset"), systemImage: "arrow.counterclockwise") {
                 appState.countdown.reset()
             }
         }
@@ -1942,7 +1968,7 @@ struct MainWindowView: View {
                 .font(.caption)
                 .foregroundStyle(.secondary)
             TextField("", text: text)
-                .textFieldStyle(.roundedBorder)
+                .orchestranaTextField()
                 .frame(width: width)
                 .multilineTextAlignment(.trailing)
                 .font(.system(.body, design: .rounded).monospacedDigit())
@@ -2157,7 +2183,7 @@ struct MainWindowView: View {
             case .dashboard:
                 return "square.grid.2x2"
             case .workspace:
-                return "sparkles.rectangle.stack"
+                return "rectangle.3.group"
             case .tasks:
                 return "checklist"
             case .calendar:
@@ -2273,7 +2299,7 @@ struct MainWindowView: View {
             case .notifications:
                 return "bell.badge"
             case .aiFeatures:
-                return "sparkles"
+                return "cpu"
             case .account:
                 return "person.crop.circle"
             }
@@ -2296,7 +2322,7 @@ struct MainWindowView: View {
                 Spacer()
                 HStack(spacing: 6) {
                     TextField("", text: $text)
-                        .textFieldStyle(.roundedBorder)
+                        .orchestranaTextField()
                         .frame(width: 64)
                         .multilineTextAlignment(.trailing)
                         .font(.system(.body, design: .rounded).monospacedDigit())
@@ -2375,16 +2401,14 @@ struct MainWindowView: View {
         var body: some View {
             HStack {
                 Text(languageManager.text("timer.long_break_interval"))
-                    .font(.system(.body, design: .rounded))
+                    .font(.system(.body, weight: .medium))
                 Spacer()
-                Stepper(value: $interval, in: 1...12) {
-                    Text(languageManager.format("timer.long_break_interval.every_sessions", interval))
-                        .font(.system(.body, design: .rounded).monospacedDigit())
-                        .foregroundStyle(.secondary)
-                }
-                .onChange(of: interval) { _, _ in
-                    onCommit()
-                }
+                OrchestranaStepControl(
+                    value: $interval,
+                    in: 1...12,
+                    valueText: { languageManager.format("timer.long_break_interval.every_sessions", $0) },
+                    onChange: onCommit
+                )
             }
             .accessibilityElement(children: .combine)
             .accessibilityLabel(languageManager.text("timer.long_break_interval"))
@@ -2394,43 +2418,35 @@ struct MainWindowView: View {
 
     private struct ActionButton: View {
         let title: String
+        let systemImage: String?
+        let variant: OrchestranaButtonVariant
         let isEnabled: Bool
         let action: () -> Void
-        @State private var isHovering = false
-        @GestureState private var isPressing = false
-        @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
-        init(_ title: String, isEnabled: Bool = true, action: @escaping () -> Void) {
+        init(
+            _ title: String,
+            systemImage: String? = nil,
+            variant: OrchestranaButtonVariant = .secondary,
+            isEnabled: Bool = true,
+            action: @escaping () -> Void
+        ) {
             self.title = title
+            self.systemImage = systemImage
+            self.variant = variant
             self.isEnabled = isEnabled
             self.action = action
         }
 
         var body: some View {
-            Button(title, action: action)
-                .buttonStyle(.bordered)
-                .controlSize(.regular)
-                .disabled(!isEnabled)
-                .opacity(isEnabled ? 1.0 : 0.45)
-                .scaleEffect(pressScale)
-                .background(
-                    RoundedRectangle(cornerRadius: 6)
-                        .fill(isHovering && isEnabled ? Color.accentColor.opacity(0.08) : .clear)
-                )
-                .animation(reduceMotion ? nil : .easeOut(duration: 0.2), value: isHovering)
-                .animation(reduceMotion ? nil : .easeOut(duration: 0.18), value: isPressing)
-                .onHover { hovering in
-                    isHovering = hovering
+            Button(action: action) {
+                if let systemImage {
+                    Label(title, systemImage: systemImage)
+                } else {
+                    Text(title)
                 }
-                .simultaneousGesture(
-                    DragGesture(minimumDistance: 0)
-                        .updating($isPressing) { _, state, _ in state = true }
-                )
-        }
-
-        private var pressScale: CGFloat {
-            guard isEnabled, !reduceMotion else { return 1.0 }
-            return isPressing ? 0.98 : 1.0
+            }
+                .orchestranaButton(variant, minWidth: 76)
+                .disabled(!isEnabled)
         }
     }
 
@@ -3007,6 +3023,37 @@ struct MainWindowView: View {
         }
     }
 
+    private func timerStateBadge(for state: TimerState) -> some View {
+        Label {
+            Text(languageManager.format("timer.state_format", labelForPomodoroState(state)))
+                .font(.system(.subheadline, design: .rounded).weight(.semibold))
+        } icon: {
+            Circle()
+                .fill(timerStateTint(for: state))
+                .frame(width: 7, height: 7)
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 6)
+        .background(timerStateTint(for: state).opacity(0.12), in: Capsule(style: .continuous))
+        .foregroundStyle(timerStateTint(for: state))
+        .accessibilityElement(children: .combine)
+    }
+
+    private func timerStateTint(for state: TimerState) -> Color {
+        switch state {
+        case .idle:
+            return .secondary
+        case .running:
+            return .green
+        case .paused:
+            return .orange
+        case .breakRunning:
+            return .blue
+        case .breakPaused:
+            return .purple
+        }
+    }
+
     private func titleForPomodoroMode(_ mode: PomodoroTimerEngine.Mode) -> String {
         switch mode {
         case .work:
@@ -3259,6 +3306,38 @@ struct MainWindowView: View {
         )
     }
 
+    private func presetSelectorOptions(includeCustom: Bool = true) -> [OrchestranaSelectorOption<PresetSelection>] {
+        var options = Preset.builtIn.map { preset in
+            OrchestranaSelectorOption(
+                preset.name,
+                value: PresetSelection.preset(preset),
+                subtitle: presetSubtitle(for: preset),
+                systemImage: "timer"
+            )
+        }
+
+        if includeCustom {
+            options.append(
+                OrchestranaSelectorOption(
+                    languageManager.text("timer.custom"),
+                    value: PresetSelection.custom,
+                    subtitle: "Manual",
+                    systemImage: "slider.horizontal.3"
+                )
+            )
+        }
+
+        return options
+    }
+
+    private func presetSubtitle(for preset: Preset) -> String {
+        let config = preset.durationConfig
+        let work = max(1, config.workDuration / 60)
+        let shortBreak = max(1, config.shortBreakDuration / 60)
+        let longBreak = max(1, config.longBreakDuration / 60)
+        return "\(work)m / \(shortBreak)m / \(longBreak)m"
+    }
+
     private var dashboardPomodoroConfigurationPanel: some View {
         VStack(alignment: .leading, spacing: 12) {
             Divider()
@@ -3267,15 +3346,13 @@ struct MainWindowView: View {
                 .font(.headline)
                 .foregroundStyle(.secondary)
 
-            Picker(languageManager.text("timer.preset"), selection: dashboardPresetSelectionBinding) {
-                ForEach(Preset.builtIn) { preset in
-                    Text(preset.name)
-                        .tag(PresetSelection.preset(preset))
-                }
-                Text(languageManager.text("timer.custom"))
-                    .tag(PresetSelection.custom)
-            }
-            .pickerStyle(.segmented)
+            OrchestranaSelector(
+                selection: dashboardPresetSelectionBinding,
+                options: presetSelectorOptions(),
+                layout: .grid,
+                minOptionWidth: 104,
+                accessibilityLabel: languageManager.text("timer.preset")
+            )
 
             dashboardDurationStepperRow(
                 title: languageManager.text("timer.work"),
@@ -3295,13 +3372,13 @@ struct MainWindowView: View {
 
             HStack {
                 Text(languageManager.text("timer.long_break_interval"))
-                    .font(.system(.body, design: .rounded))
+                    .font(.system(.body, weight: .medium))
                 Spacer()
-                Stepper(value: $dashboardLongBreakInterval, in: 1...12) {
-                    Text(languageManager.format("timer.long_break_interval.every_sessions", dashboardLongBreakInterval))
-                        .font(.system(.body, design: .rounded).monospacedDigit())
-                        .foregroundStyle(.secondary)
-                }
+                OrchestranaStepControl(
+                    value: $dashboardLongBreakInterval,
+                    in: 1...12,
+                    valueText: { languageManager.format("timer.long_break_interval.every_sessions", $0) }
+                )
             }
 
             Text("These controls affect the current dashboard session only. Change Settings to update the default Pomodoro setup.")
@@ -3321,13 +3398,13 @@ struct MainWindowView: View {
     ) -> some View {
         HStack {
             Text(title)
-                .font(.system(.body, design: .rounded))
+                .font(.system(.body, weight: .medium))
             Spacer()
-            Stepper(value: value, in: range) {
-                Text(languageManager.format("tasks.pomodoro_estimate_value", value.wrappedValue).replacingOccurrences(of: " Pomodoros", with: " min").replacingOccurrences(of: " Pomodoro", with: " min"))
-                    .font(.system(.body, design: .rounded).monospacedDigit())
-                    .foregroundStyle(.secondary)
-            }
+            OrchestranaStepControl(
+                value: value,
+                in: range,
+                valueText: { "\($0) min" }
+            )
         }
     }
 
@@ -3431,6 +3508,13 @@ struct MainWindowView: View {
             countdownSecondsText = String(format: "%02d", committed)
             updateDurationConfig(countdownSeconds: committed)
         }
+    }
+
+    private var countdownPresetSelection: Binding<Int> {
+        Binding(
+            get: { max(1, appState.durationConfig.countdownDuration / 60) },
+            set: { applyCountdownPreset(minutes: $0) }
+        )
     }
 
     private func applyCountdownPreset(minutes: Int) {
@@ -3882,7 +3966,7 @@ private struct SettingsPlansSheet: View {
                 Button("Done") {
                     dismiss()
                 }
-                .buttonStyle(.bordered)
+                .orchestranaButton(.secondary)
             }
 
             ScrollView {

--- a/macos/Pomodoro/Pomodoro/MusicPanelView.swift
+++ b/macos/Pomodoro/Pomodoro/MusicPanelView.swift
@@ -19,17 +19,17 @@ struct MusicPanelView: View {
                     Button(action: { localMusicPlayer.previous() }) {
                         Image(systemName: "backward.fill")
                     }
-                    .buttonStyle(.borderless)
+                    .orchestranaButton(.subtle)
 
                     Button(action: togglePlayback) {
                         Image(systemName: localMusicPlayer.isPlaying ? "pause.fill" : "play.fill")
                     }
-                    .buttonStyle(.borderless)
+                    .orchestranaButton(.subtle)
 
                     Button(action: { localMusicPlayer.next() }) {
                         Image(systemName: "forward.fill")
                     }
-                    .buttonStyle(.borderless)
+                    .orchestranaButton(.subtle)
                 }
                 .font(.system(size: 18, weight: .semibold))
 
@@ -40,7 +40,7 @@ struct MusicPanelView: View {
                 Button(localizationManager.text("audio.choose_music")) {
                     localMusicPlayer.loadFiles()
                 }
-                .buttonStyle(.borderedProminent)
+                .orchestranaButton(.primary)
             }
         }
         .padding(20)

--- a/macos/Pomodoro/Pomodoro/OnboardingFlowView.swift
+++ b/macos/Pomodoro/Pomodoro/OnboardingFlowView.swift
@@ -125,7 +125,7 @@ struct OnboardingFlowView: View {
                 Button(topActionTitle) {
                     handleTopAction()
                 }
-                .buttonStyle(.borderless)
+                .orchestranaButton(.subtle)
                 .font(.system(size: 13, weight: .medium))
             }
         }
@@ -409,7 +409,7 @@ struct OnboardingFlowView: View {
                 Button(localizationManager.text("common.open_system_settings")) {
                     openNotificationSettings()
                 }
-                .buttonStyle(.bordered)
+                .orchestranaButton(.secondary)
                 .controlSize(.large)
             }
         }
@@ -650,7 +650,7 @@ struct OnboardingFlowView: View {
         VStack(alignment: .leading, spacing: 22) {
             VStack(alignment: .leading, spacing: 14) {
                 upgradeFeatureRow(
-                    symbol: "sparkles",
+                    symbol: "cpu",
                     title: localizationManager.text("onboarding.upgrade.feature.models_title"),
                     detail: localizationManager.text("onboarding.upgrade.feature.models_body")
                 )
@@ -687,7 +687,7 @@ struct OnboardingFlowView: View {
                     message: localizationManager.text("onboarding.upgrade.view_plans_body")
                 )
             }
-            .buttonStyle(.bordered)
+            .orchestranaButton(.secondary)
         }
     }
 
@@ -722,7 +722,7 @@ struct OnboardingFlowView: View {
                     Button(localizationManager.text("onboarding.back")) {
                         back()
                     }
-                    .buttonStyle(.bordered)
+                    .orchestranaButton(.secondary)
                     .controlSize(.large)
                     .font(onboardingPrimaryLabelFont)
                     .frame(minWidth: 112, minHeight: 46)
@@ -732,7 +732,7 @@ struct OnboardingFlowView: View {
                     Button(footerActionTitle) {
                         performFooterAction()
                     }
-                    .buttonStyle(.borderedProminent)
+                    .orchestranaButton(.primary)
                     .controlSize(.large)
                     .font(onboardingPrimaryLabelFont)
                     .frame(minWidth: 168, minHeight: 46)
@@ -1183,7 +1183,7 @@ private enum WelcomePreviewItem: String, CaseIterable, Identifiable {
     var symbol: String {
         switch self {
         case .ai:
-            return "sparkles"
+            return "cpu"
         case .focus:
             return "timer"
         case .calendar:

--- a/macos/Pomodoro/Pomodoro/SettingsPermissionsView.swift
+++ b/macos/Pomodoro/Pomodoro/SettingsPermissionsView.swift
@@ -237,7 +237,7 @@ struct SettingsPermissionsView: View {
                         Text("Restore & Sync Subscription")
                     }
                 }
-                .buttonStyle(.bordered)
+                .orchestranaButton(.secondary)
                 .disabled(subscriptionStore.isRestoring)
             }
 
@@ -281,7 +281,7 @@ struct SettingsPermissionsView: View {
                         message: localizationManager.text("settings.ai_planning.free_description")
                     )
                 }
-                .buttonStyle(.borderedProminent)
+                .orchestranaButton(.primary)
             }
         case .deepSeek:
             VStack(alignment: .leading, spacing: 8) {
@@ -383,7 +383,7 @@ struct SettingsPermissionsView: View {
     @ViewBuilder
     private func modelRow(_ title: String) -> some View {
         HStack(spacing: 10) {
-            Image(systemName: "sparkles")
+            Image(systemName: "cpu")
                 .font(.caption.weight(.semibold))
                 .foregroundStyle(.secondary)
             Text(title)
@@ -433,14 +433,14 @@ struct SettingsPermissionsView: View {
                         .font(.subheadline)
                         .fontWeight(.medium)
                 }
-                .buttonStyle(.bordered)
+                .orchestranaButton(.secondary)
             } else {
                 Button(action: action) {
                     Text(localizationManager.text("permissions.enable"))
                         .font(.subheadline)
                         .fontWeight(.medium)
                 }
-                .buttonStyle(.borderedProminent)
+                .orchestranaButton(.primary)
             }
         }
     }
@@ -608,12 +608,14 @@ struct PlansComparisonView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
             HStack(alignment: .center, spacing: 10) {
-                Picker("Billing", selection: selectedBillingCycle) {
-                    ForEach(PlanBillingCycle.allCases) { cycle in
-                        Text(cycle.title).tag(cycle)
-                    }
-                }
-                .pickerStyle(.segmented)
+                OrchestranaSelector(
+                    selection: selectedBillingCycle,
+                    options: PlanBillingCycle.allCases.map {
+                        OrchestranaSelectorOption($0.title, value: $0)
+                    },
+                    minOptionWidth: 96,
+                    accessibilityLabel: "Billing"
+                )
                 .frame(maxWidth: 260)
             }
 
@@ -658,14 +660,14 @@ struct PlansComparisonView: View {
                         Text("Restore & Sync Subscription")
                     }
                 }
-                .buttonStyle(.bordered)
+                .orchestranaButton(.secondary)
                 .disabled(subscriptionStore.isRestoring)
 
                 Button("View Full Comparison") {
                     guard let url = URL(string: "https://orchestrana.app/comparison.html") else { return }
                     openURL(url)
                 }
-                .buttonStyle(.bordered)
+                .orchestranaButton(.secondary)
             }
         }
         .task(id: authViewModel.currentUser?.uid) {
@@ -989,7 +991,7 @@ struct PlanCardView: View {
     private var ctaSection: some View {
         if tier == .free {
             Button(isCurrentFreePlan ? "Current Plan" : "Free") { }
-                .buttonStyle(.bordered)
+                .orchestranaButton(.secondary)
                 .disabled(true)
         } else if let product {
             Button {
@@ -1002,7 +1004,7 @@ struct PlanCardView: View {
                     Text(buttonTitle)
                 }
             }
-            .buttonStyle(.borderedProminent)
+            .orchestranaButton(.primary)
             .disabled(isDisabled)
         } else {
             VStack(alignment: .leading, spacing: 8) {
@@ -1017,7 +1019,7 @@ struct PlanCardView: View {
                         Text(!authViewModel.isAuthenticated ? "Sign in to continue" : "Loading…")
                     }
                 }
-                .buttonStyle(.bordered)
+                .orchestranaButton(.secondary)
                 .disabled(true)
 
                 if let productLoadErrorMessage, !productLoadErrorMessage.isEmpty {
@@ -1172,7 +1174,7 @@ struct SubscriptionUpgradeSheetView: View {
                     Button(localizationManager.text("common.cancel")) {
                         dismiss()
                     }
-                    .buttonStyle(.bordered)
+                    .orchestranaButton(.secondary)
 
                     Spacer()
 
@@ -1183,7 +1185,7 @@ struct SubscriptionUpgradeSheetView: View {
                             await subscriptionStore.purchase(product)
                         }
                     }
-                    .buttonStyle(.borderedProminent)
+                    .orchestranaButton(.primary)
                     .disabled(isPurchaseButtonDisabled)
                 }
             }
@@ -1291,7 +1293,7 @@ struct PurchaseAuthenticationSheet: View {
                     authViewModel.dismissPurchaseLoginPrompt()
                     dismiss()
                 }
-                .buttonStyle(.bordered)
+                .orchestranaButton(.secondary)
             }
         }
         .padding(24)

--- a/macos/Pomodoro/Pomodoro/TodoListView.swift
+++ b/macos/Pomodoro/Pomodoro/TodoListView.swift
@@ -94,6 +94,26 @@ struct TodoListView: View {
         var id: String { rawValue }
     }
 
+    private var taskSegmentOptions: [OrchestranaSelectorOption<Segment>] {
+        [
+            OrchestranaSelectorOption(localizationManager.text("tasks.segment.active"), value: .active, systemImage: "circle"),
+            OrchestranaSelectorOption(localizationManager.text("tasks.segment.completed"), value: .completed, systemImage: "checkmark.circle")
+        ]
+    }
+
+    private var taskViewModeOptions: [OrchestranaSelectorOption<TaskViewMode>] {
+        [
+            OrchestranaSelectorOption(localizationManager.text("tasks.view.list"), value: .list, systemImage: "list.bullet"),
+            OrchestranaSelectorOption(localizationManager.text("tasks.view.matrix"), value: .matrix, systemImage: "square.grid.2x2")
+        ]
+    }
+
+    private var priorityOptions: [OrchestranaSelectorOption<TodoItem.Priority>] {
+        TodoItem.Priority.allCases.map { priority in
+            OrchestranaSelectorOption(priority.displayName, value: priority)
+        }
+    }
+
     private struct EventTaskGroupEntry: Identifiable {
         let id: UUID
         let eventTitle: String
@@ -173,7 +193,7 @@ struct TodoListView: View {
                 Button(action: { openEditorForNew() }) {
                     Label(localizationManager.text("tasks.add_task"), systemImage: "plus")
                 }
-                .buttonStyle(.borderedProminent)
+                .orchestranaButton(.primary)
                 
                 if permissionsManager.isRemindersAuthorized {
                     Button {
@@ -189,7 +209,7 @@ struct TodoListView: View {
                             Label(localizationManager.text("tasks.sync_all_tasks"), systemImage: "arrow.triangle.2.circlepath")
                         }
                     }
-                    .buttonStyle(.borderedProminent)
+                    .orchestranaButton(.primary)
                     .disabled(remindersSync.isSyncing)
                 }
 
@@ -209,17 +229,18 @@ struct TodoListView: View {
                         }
                     }
                 } label: {
-                    Label(localizationManager.text("tasks.ai_assistant.button"), systemImage: "sparkles")
+                    Label(localizationManager.text("tasks.ai_assistant.button"), systemImage: "list.bullet.rectangle")
                 }
-                .buttonStyle(.bordered)
+                .orchestranaButton(.secondary)
                 
                 Spacer()
 
-                Picker("", selection: $taskViewMode) {
-                    Text(localizationManager.text("tasks.view.list")).tag(TaskViewMode.list)
-                    Text(localizationManager.text("tasks.view.matrix")).tag(TaskViewMode.matrix)
-                }
-                .pickerStyle(.segmented)
+                OrchestranaSelector(
+                    selection: $taskViewMode,
+                    options: taskViewModeOptions,
+                    minOptionWidth: 86,
+                    accessibilityLabel: localizationManager.text("tasks.title")
+                )
                 .frame(maxWidth: 220)
                 .onChange(of: taskViewMode) { _, newMode in
                     guard newMode == .matrix else { return }
@@ -235,11 +256,12 @@ struct TodoListView: View {
                     }
                 }
                 
-                Picker("", selection: $selectedSegment) {
-                    Text(localizationManager.text("tasks.segment.active")).tag(Segment.active)
-                    Text(localizationManager.text("tasks.segment.completed")).tag(Segment.completed)
-                }
-                .pickerStyle(.segmented)
+                OrchestranaSelector(
+                    selection: $selectedSegment,
+                    options: taskSegmentOptions,
+                    minOptionWidth: 92,
+                    accessibilityLabel: localizationManager.text("tasks.title")
+                )
                 .frame(maxWidth: 220)
             }
             .padding(.horizontal, 32)
@@ -408,7 +430,7 @@ struct TodoListView: View {
                     await permissionsManager.requestRemindersPermission()
                 }
             }
-            .buttonStyle(.bordered)
+            .orchestranaButton(.secondary)
         }
         .padding(12)
         .background(Color.orange.opacity(0.1))
@@ -763,14 +785,14 @@ struct TodoListView: View {
                             set: { subtaskDrafts[item.id] = $0 }
                         )
                     )
-                    .textFieldStyle(.roundedBorder)
+                    .orchestranaTextField()
 
                     Button(localizationManager.text("common.add")) {
                         let draft = subtaskDrafts[item.id] ?? ""
                         todoStore.addSubtask(to: item.id, title: draft)
                         subtaskDrafts[item.id] = ""
                     }
-                    .buttonStyle(.bordered)
+                    .orchestranaButton(.secondary)
                     .disabled((subtaskDrafts[item.id] ?? "").trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
                 }
             } else {
@@ -783,7 +805,7 @@ struct TodoListView: View {
                 } label: {
                     Label("Subtasks", systemImage: "lock.fill")
                 }
-                .buttonStyle(.bordered)
+                .orchestranaButton(.secondary)
             }
         }
         .padding(.leading, 34)
@@ -1242,16 +1264,18 @@ struct TodoListView: View {
                 
                 VStack(alignment: .leading, spacing: 10) {
                     TextField(localizationManager.text("tasks.editor.title_placeholder"), text: $titleField)
-                        .textFieldStyle(.roundedBorder)
+                        .orchestranaTextField()
 
                     VStack(alignment: .leading, spacing: 6) {
                         Text(localizationManager.text("tasks.ai_plan.estimated_hours"))
                             .font(.subheadline)
                             .foregroundStyle(.secondary)
 
-                        Stepper(value: $aiEstimatedHours, in: 1...40) {
-                            Text(localizationManager.format("tasks.ai_plan.estimated_hours_value", aiEstimatedHours))
-                        }
+                        OrchestranaStepControl(
+                            value: $aiEstimatedHours,
+                            in: 1...40,
+                            valueText: { localizationManager.format("tasks.ai_plan.estimated_hours_value", $0) }
+                        )
                     }
 
                     if featureGate.canUseAdvancedTasks {
@@ -1260,12 +1284,12 @@ struct TodoListView: View {
                                 .font(.subheadline)
                                 .foregroundStyle(.secondary)
 
-                            Picker("", selection: $priorityField) {
-                                ForEach(TodoItem.Priority.allCases, id: \.self) { priority in
-                                    Text(priority.displayName).tag(priority)
-                                }
-                            }
-                            .pickerStyle(.segmented)
+                            OrchestranaSelector(
+                                selection: $priorityField,
+                                options: priorityOptions,
+                                minOptionWidth: 72,
+                                accessibilityLabel: localizationManager.text("tasks.editor.priority")
+                            )
                         }
 
                         VStack(alignment: .leading, spacing: 6) {
@@ -1273,9 +1297,11 @@ struct TodoListView: View {
                                 .font(.subheadline)
                                 .foregroundStyle(.secondary)
 
-                            Stepper(value: $pomodoroEstimateField, in: 1...20) {
-                                Text(localizationManager.format("tasks.pomodoro_estimate_value", pomodoroEstimateField))
-                            }
+                            OrchestranaStepControl(
+                                value: $pomodoroEstimateField,
+                                in: 1...20,
+                                valueText: { localizationManager.format("tasks.pomodoro_estimate_value", $0) }
+                            )
                         }
                     }
 
@@ -1343,14 +1369,14 @@ struct TodoListView: View {
                                     }
                                     .disabled(titleField.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
                                 } label: {
-                                    Label("Task AI", systemImage: "sparkles")
+                                    Label("Task AI", systemImage: "text.badge.plus")
                                 }
                                 .menuStyle(.borderlessButton)
                             }
                         }
 
                         TextField(localizationManager.text("tasks.editor.notes_placeholder"), text: $descriptionField, axis: .vertical)
-                            .textFieldStyle(.roundedBorder)
+                            .orchestranaTextField()
                         if let aiDescriptionErrorMessage, !aiDescriptionErrorMessage.isEmpty {
                             Text(aiDescriptionErrorMessage)
                                 .font(.footnote)
@@ -1371,7 +1397,7 @@ struct TodoListView: View {
                         } label: {
                             Label("Markdown Descriptions", systemImage: "lock.fill")
                         }
-                        .buttonStyle(.bordered)
+                        .orchestranaButton(.secondary)
                     }
 
                     if featureGate.canUseSubtasks, !editorSubtasks.isEmpty {
@@ -1404,7 +1430,7 @@ struct TodoListView: View {
                         .font(.subheadline)
                         .foregroundStyle(.secondary)
                     TextField(localizationManager.text("tasks.editor.tags_placeholder"), text: $tagsField)
-                        .textFieldStyle(.roundedBorder)
+                        .orchestranaTextField()
                     
                     Toggle(localizationManager.text("tasks.editor.sync_to_calendar"), isOn: $syncToCalendarField)
                         .toggleStyle(.switch)
@@ -1427,7 +1453,7 @@ struct TodoListView: View {
                         resetEditor()
                         showingEditor = false
                     }
-                    .buttonStyle(.bordered)
+                    .orchestranaButton(.secondary)
                     
                     Spacer()
 
@@ -1439,10 +1465,10 @@ struct TodoListView: View {
                                 Text(localizationManager.text("tasks.ai_plan.loading"))
                             }
                         } else {
-                            Label(localizationManager.text("tasks.ai_plan.button"), systemImage: "sparkles")
+                            Label(localizationManager.text("tasks.ai_plan.button"), systemImage: "calendar.badge.clock")
                         }
                     }
-                    .buttonStyle(.bordered)
+                    .orchestranaButton(.secondary)
                     .disabled(isGeneratingAIPlan || titleField.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
                     
                     Button(editingItem == nil ? localizationManager.text("common.add") : localizationManager.text("common.save")) {
@@ -1450,7 +1476,7 @@ struct TodoListView: View {
                             await saveTask()
                         }
                     }
-                    .buttonStyle(.borderedProminent)
+                    .orchestranaButton(.primary)
                     .keyboardShortcut(.return, modifiers: [.command])
                     .disabled(titleField.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
                 }
@@ -1513,7 +1539,7 @@ struct TodoListView: View {
                 Button(localizationManager.text("common.cancel")) {
                     showAITaskDraftSheet = false
                 }
-                .buttonStyle(.bordered)
+                .orchestranaButton(.secondary)
 
                 Spacer()
 
@@ -1532,7 +1558,7 @@ struct TodoListView: View {
                         Text("Generate Draft")
                     }
                 }
-                .buttonStyle(.borderedProminent)
+                .orchestranaButton(.primary)
                 .disabled(isGeneratingAITaskDraft || aiTaskDraftPrompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
             }
         }
@@ -2285,14 +2311,14 @@ extension TodoListView {
             } label: {
                 Label(localizationManager.text("common.move"), systemImage: "arrow.right.circle")
             }
-            .buttonStyle(.bordered)
+            .orchestranaButton(.secondary)
             
             Button {
                 applyBatchClearDate()
             } label: {
                 Label(localizationManager.text("tasks.action.clear_date"), systemImage: "calendar.badge.minus")
             }
-            .buttonStyle(.bordered)
+            .orchestranaButton(.secondary)
             
             Spacer()
             
@@ -2301,8 +2327,7 @@ extension TodoListView {
             } label: {
                 Label(localizationManager.text("common.delete"), systemImage: "trash")
             }
-            .buttonStyle(.borderedProminent)
-            .tint(.red)
+            .orchestranaButton(.destructive)
         }
         .alert(localizationManager.format("tasks.batch.delete_confirmation_title", selectedTaskIDs.count), isPresented: $showBatchDeleteConfirmation) {
             Button(localizationManager.text("common.delete"), role: .destructive) {


### PR DESCRIPTION
## Summary

This PR stabilizes the Orchestrana macOS UI after the first styling pass. It moves the app toward a calmer Native Utility direction: less AI-forward visual language, more consistent control styling, and custom selector controls for the visible Pomodoro/task/calendar/settings configuration surfaces.

## What Changed

- Added a reusable Orchestrana control layer in `AppAppearance.swift`:
  - Tuned `OrchestranaButtonStyle` to use smaller radii, lighter shadows, system typography, calmer hover/pressed/disabled states, and a new `subtle` variant.
  - Added `OrchestranaSelector` and `OrchestranaSelectorOption` for custom segmented/preset-style choices without SwiftUI segmented picker chrome.
  - Added `OrchestranaStepControl` for numeric +/- controls without default SwiftUI steppers.
  - Added `OrchestranaControlGroup` and `OrchestranaFormRow` for follow-on consistency across app content.

- Replaced visible default selector controls:
  - Pomodoro preset selectors, dashboard session setup, long-break interval, countdown presets, language/font/appearance selectors, notification selectors, task view/filter selectors, task priority, task estimates, calendar view selector, event duration, billing cycle, and AI assistant estimated hours now use the custom control system.
  - Removed the old `orchestranaSegmentedPicker()` wrapper that still depended on `.pickerStyle(.segmented)`.
  - Left native `DatePicker`, `Menu`, `Toggle`, command menus, sliders, and system dialogs in place as deliberate platform-native exceptions.

- Decluttered and unified core surfaces:
  - Pomodoro/dashboard actions now use icon-labeled Start/Pause/Resume/Reset/Skip controls with one primary action style and calmer secondary/destructive treatments.
  - The Pomodoro timing presets like `25 / 5`, `50 / 10`, custom, and countdown presets are now custom option cards/chips instead of default Swift selectors.
  - Tasks and Calendar toolbars now use custom selectors and neutral productivity icons instead of sparkle-forward AI styling.
  - Settings/account/subscription/onboarding/audio surfaces inherit the calmer button styling and replacement selector language.

- Reduced AI-looking visual language:
  - Replaced `sparkles` icons throughout app content with more neutral productivity/system symbols such as `list.bullet.rectangle`, `calendar.badge.clock`, `text.badge.plus`, `cpu`, and chart/workspace symbols.
  - Kept AI features discoverable, but visually secondary to the productivity workflow.

## User Impact

- Pomodoro timing configuration should no longer show default SwiftUI segmented controls or steppers.
- Buttons across the app should feel less decorative and more like a cohesive macOS productivity app.
- Tasks, Calendar, Settings, subscription billing, onboarding, and AI assistant surfaces now share the same selector/step-control vocabulary.
- Loading and disabled states keep stable button sizing through the shared button style.

## Validation

- Built successfully:
  - `xcodebuild -project macos/Pomodoro/Pomodoro.xcodeproj -scheme "Orchestrana Debug" -configuration Debug -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build`
- Default SwiftUI button chrome audit:
  - `rg -n "\\.buttonStyle\\(\\.(bordered|borderedProminent|borderless|link)\\)" macos/Pomodoro/Pomodoro --glob '*.swift'`
  - Result: no matches.
- Visible selector audit excluding native date pickers:
  - `rg -n "(^|[^A-Za-z])Picker\\(|Stepper\\(|orchestranaSegmentedPicker|\\.pickerStyle\\(" macos/Pomodoro/Pomodoro --glob '*.swift'`
  - Result: no matches.
- Exact broad selector audit:
  - `rg -n "Picker\\(|Stepper\\(|\\.pickerStyle\\(" macos/Pomodoro/Pomodoro --glob '*.swift'`
  - Result: only `DatePicker` matches remain, which are deliberate native exceptions.
- Whitespace check:
  - `git diff --check`
  - Result: clean.
- Installed updated local test bundle:
  - `/Applications/Orchestrana-testing.app`
  - `/Users/landen/Applications/Orchestrana-testing.app`
  - Finder metadata now reports display name `Orchestrana-testing`.

## Notes

- This is intentionally UI-only. It does not change timer behavior, sync behavior, AI gates, subscription logic, Firebase logic, data models, or command-menu behavior.
- This PR is opened as a draft because the requested manual UI pass across light/dark mode, glass/standard mode, and multiple window widths still needs human visual review.